### PR TITLE
Update title on examples page

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -1,5 +1,5 @@
 ---
-title: rst2pdf: Examples
+title: Examples
 ---
 
 # rst2pdf Examples


### PR DESCRIPTION
We don't need to prefix with "rst2pdf" as this is added after the title automatically.