### PR TITLE
Update requirement version to 3.6

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ To create your first PDF, simply install the `rst2pdf` tool, write some text, an
 
 ### Install rst2pdf
 
-`rst2pdf` requires Python 2 (upgrade to Python 3 is a work in progress).
+`rst2pdf` requires Python 3.6 or greater.
 
 **Option 1: install with pip**
 


### PR DESCRIPTION
As per [#892](https://github.com/rst2pdf/rst2pdf/issues/892), rst2pdf now requires Python 3.6 so update the home page of the website to say so.