### PR TITLE
Make example style less confusing

### DIFF
--- a/examples/document1/simple.style
+++ b/examples/document1/simple.style
@@ -10,11 +10,15 @@ styles:
         alignment: TA_LEFT
 
     heading:
-        fontName: stdBold
         fontSize: 32
         textColor: #1a8099
+
+    title:
+        parent: heading
+        fontName: stdBold
+        fontSize: 200%
 
     heading1:
         parent: heading
         fontSize: 26
-
+        fontName: stdBold


### PR DESCRIPTION
Both title and heading1 override fontName, so the fontName in heading
doesn't have any effect. Move this to title and heading1 instead where
they are effective.

Make the 200% fontSize in title explicit.

These changes don't have any effect on the output, but make the style
file easier to follow and change.