### PR TITLE
add python3 option to installation instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,6 +47,8 @@ cd rst2pdf
 sudo python setup.py install
 ```
 
+Note that you may need to use `sudo python3 setup.py install` depending on your configuration.
+
 ### Start using rst2pdf
 
 Start with a text file.  `rst2pdf` uses [ReStructured Text](http://docutils.sourceforge.net/rst.html) which is a markup format similar to (but a bit more detailed than) markdown.  Here's an example file to get you started:


### PR DESCRIPTION
Added a note to make it clear that your may need to use the `python3` command depending on your configuration.

References https://github.com/rst2pdf/rst2pdf.github.io/issues/22#issuecomment-706012215