### PR TITLE
Updates for 0.103 release

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ To create your first PDF, simply install the `rst2pdf` tool, write some text, an
 
 ### Install rst2pdf
 
-`rst2pdf` requires Python 3.8 or greater.
+`rst2pdf` requires Python 3.9 or greater.
 
 **Option 1: install with pipx**
 
@@ -50,8 +50,11 @@ Choose this option if you want the newest features, or to contribute to the proj
 ```
 git clone https://github.com/rst2pdf/rst2pdf
 cd rst2pdf
-pipx install .[aafiguresupport,mathsupport,plantumlsupport,rawhtmlsupport,sphinx,svgsupport]
+uv sync --all-extras
 ```
+
+If you don't have `uv`, please see [the uv installation docs](https://docs.astral.sh/uv/getting-started/installation/).
+
 
 ### Start using rst2pdf
 

--- a/static/manual.html
+++ b/static/manual.html
@@ -470,126 +470,118 @@ span.boxed, span.framebox {
 <li><p><a class="reference internal" href="#related-reading" id="toc-entry-2"><span class="sectnum">1.1 </span>Related Reading</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#command-line-options" id="toc-entry-3"><span class="sectnum">2 </span>Command line options</a></p></li>
-<li><p><a class="reference internal" href="#configuration-file" id="toc-entry-4"><span class="sectnum">3 </span>Configuration File</a></p></li>
-<li><p><a class="reference internal" href="#pipe-usage" id="toc-entry-5"><span class="sectnum">4 </span>Pipe usage</a></p></li>
-<li><p><a class="reference internal" href="#images" id="toc-entry-6"><span class="sectnum">5 </span>Images</a></p>
+<li><p><a class="reference internal" href="#command-line-options" id="toc-entry-3"><span class="sectnum">2 </span>Command line options</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#inline" id="toc-entry-7"><span class="sectnum">5.1 </span>Inline</a></p></li>
-<li><p><a class="reference internal" href="#supported-image-types" id="toc-entry-8"><span class="sectnum">5.2 </span>Supported Image Types</a></p></li>
-<li><p><a class="reference internal" href="#image-size" id="toc-entry-9"><span class="sectnum">5.3 </span>Image Size</a></p></li>
+<li><p><a class="reference internal" href="#general-options" id="toc-entry-4"><span class="sectnum">2.1 </span>General Options</a></p></li>
+<li><p><a class="reference internal" href="#file-and-configuration" id="toc-entry-5"><span class="sectnum">2.2 </span>File and Configuration</a></p></li>
+<li><p><a class="reference internal" href="#styling-options" id="toc-entry-6"><span class="sectnum">2.3 </span>Styling Options</a></p></li>
+<li><p><a class="reference internal" href="#pdf-options" id="toc-entry-7"><span class="sectnum">2.4 </span>PDF Options</a></p></li>
+<li><p><a class="reference internal" href="#formatting-options" id="toc-entry-8"><span class="sectnum">2.5 </span>Formatting Options</a></p></li>
+<li><p><a class="reference internal" href="#miscellaneous-options" id="toc-entry-9"><span class="sectnum">2.6 </span>Miscellaneous Options</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#styling-restructuredtext" id="toc-entry-10"><span class="sectnum">6 </span>Styling ReStructuredText</a></p>
+<li><p><a class="reference internal" href="#configuration-file" id="toc-entry-10"><span class="sectnum">3 </span>Configuration File</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#applying-styles" id="toc-entry-11"><span class="sectnum">6.1 </span>Applying Styles</a></p></li>
-<li><p><a class="reference internal" href="#headers-and-footers" id="toc-entry-12"><span class="sectnum">6.2 </span>Headers and Footers</a></p></li>
-<li><p><a class="reference internal" href="#footnotes" id="toc-entry-13"><span class="sectnum">6.3 </span>Footnotes</a></p></li>
+<li><p><a class="reference internal" href="#configuration-options" id="toc-entry-11"><span class="sectnum">3.1 </span>Configuration Options</a></p></li>
+<li><p><a class="reference internal" href="#example-configuration-file" id="toc-entry-12"><span class="sectnum">3.2 </span>Example Configuration File</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#customizing-pdf-output" id="toc-entry-14"><span class="sectnum">7 </span>Customizing PDF Output</a></p>
+<li><p><a class="reference internal" href="#pipe-usage" id="toc-entry-13"><span class="sectnum">4 </span>Pipe usage</a></p></li>
+<li><p><a class="reference internal" href="#images" id="toc-entry-14"><span class="sectnum">5 </span>Images</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#using-stylesheets" id="toc-entry-15"><span class="sectnum">7.1 </span>Using Stylesheets</a></p></li>
-<li><p><a class="reference internal" href="#included-stylesheets" id="toc-entry-16"><span class="sectnum">7.2 </span>Included StyleSheets</a></p></li>
-<li><p><a class="reference internal" href="#default-stylesheet" id="toc-entry-17"><span class="sectnum">7.3 </span>Default Stylesheet</a></p></li>
-<li><p><a class="reference internal" href="#migrating-stylesheet-format" id="toc-entry-18"><span class="sectnum">7.4 </span>Migrating Stylesheet Format</a></p></li>
-<li><p><a class="reference internal" href="#migrating-to-the-new-default-stylesheet" id="toc-entry-19"><span class="sectnum">7.5 </span>Migrating to the New Default Stylesheet</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#updated-font-alias-names" id="toc-entry-20"><span class="sectnum">7.5.1 </span>Updated Font Alias Names</a></p></li>
-<li><p><a class="reference internal" href="#updated-pate-template-names" id="toc-entry-21"><span class="sectnum">7.5.2 </span>Updated Pate Template Names</a></p></li>
+<li><p><a class="reference internal" href="#inline" id="toc-entry-15"><span class="sectnum">5.1 </span>Inline</a></p></li>
+<li><p><a class="reference internal" href="#supported-image-types" id="toc-entry-16"><span class="sectnum">5.2 </span>Supported Image Types</a></p></li>
+<li><p><a class="reference internal" href="#image-size" id="toc-entry-17"><span class="sectnum">5.3 </span>Image Size</a></p></li>
 </ul>
 </li>
+<li><p><a class="reference internal" href="#styling-restructuredtext" id="toc-entry-18"><span class="sectnum">6 </span>Styling ReStructuredText</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#applying-styles" id="toc-entry-19"><span class="sectnum">6.1 </span>Applying Styles</a></p></li>
+<li><p><a class="reference internal" href="#headers-and-footers" id="toc-entry-20"><span class="sectnum">6.2 </span>Headers and Footers</a></p></li>
+<li><p><a class="reference internal" href="#footnotes" id="toc-entry-21"><span class="sectnum">6.3 </span>Footnotes</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#creating-stylesheets" id="toc-entry-22"><span class="sectnum">8 </span>Creating Stylesheets</a></p>
+<li><p><a class="reference internal" href="#customizing-pdf-output" id="toc-entry-22"><span class="sectnum">7 </span>Customizing PDF Output</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#styles-in-detail" id="toc-entry-23"><span class="sectnum">8.1 </span>Styles in Detail</a></p></li>
-<li><p><a class="reference internal" href="#style-elements" id="toc-entry-24"><span class="sectnum">8.2 </span>Style Elements</a></p>
+<li><p><a class="reference internal" href="#using-stylesheets" id="toc-entry-23"><span class="sectnum">7.1 </span>Using Stylesheets</a></p></li>
+<li><p><a class="reference internal" href="#included-stylesheets" id="toc-entry-24"><span class="sectnum">7.2 </span>Included StyleSheets</a></p></li>
+<li><p><a class="reference internal" href="#default-stylesheet" id="toc-entry-25"><span class="sectnum">7.3 </span>Default Stylesheet</a></p></li>
+<li><p><a class="reference internal" href="#migrating-stylesheet-format" id="toc-entry-26"><span class="sectnum">7.4 </span>Migrating Stylesheet Format</a></p></li>
+<li><p><a class="reference internal" href="#migrating-to-the-new-default-stylesheet" id="toc-entry-27"><span class="sectnum">7.5 </span>Migrating to the New Default Stylesheet</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#inline-styles" id="toc-entry-25"><span class="sectnum">8.2.1 </span>Inline Styles</a></p></li>
-<li><p><a class="reference internal" href="#lists" id="toc-entry-26"><span class="sectnum">8.2.2 </span>Lists</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#page-layout" id="toc-entry-27"><span class="sectnum">8.3 </span>Page Layout</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#page-setup" id="toc-entry-28"><span class="sectnum">8.3.1 </span>Page Setup</a></p></li>
-<li><p><a class="reference internal" href="#page-templates" id="toc-entry-29"><span class="sectnum">8.3.2 </span>Page Templates</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#font-alias" id="toc-entry-30"><span class="sectnum">8.4 </span>Font Alias</a></p></li>
-<li><p><a class="reference internal" href="#widows-and-orphans" id="toc-entry-31"><span class="sectnum">8.5 </span>Widows and Orphans</a></p></li>
-<li><p><a class="reference internal" href="#table-styles" id="toc-entry-32"><span class="sectnum">8.6 </span>Table Styles</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#syntax-highlighting" id="toc-entry-33"><span class="sectnum">9 </span>Syntax Highlighting</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#file-inclusion" id="toc-entry-34"><span class="sectnum">9.1 </span>File inclusion</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#include-with-boundaries" id="toc-entry-35"><span class="sectnum">9.1.1 </span>Include with Boundaries</a></p></li>
-<li><p><a class="reference internal" href="#options" id="toc-entry-36"><span class="sectnum">9.1.2 </span>Options</a></p></li>
+<li><p><a class="reference internal" href="#updated-font-alias-names" id="toc-entry-28"><span class="sectnum">7.5.1 </span>Updated Font Alias Names</a></p></li>
+<li><p><a class="reference internal" href="#updated-pate-template-names" id="toc-entry-29"><span class="sectnum">7.5.2 </span>Updated Pate Template Names</a></p></li>
 </ul>
 </li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#fonts" id="toc-entry-37"><span class="sectnum">10 </span>Fonts</a></p>
+<li><p><a class="reference internal" href="#creating-stylesheets" id="toc-entry-30"><span class="sectnum">8 </span>Creating Stylesheets</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#standard-pdf-fonts" id="toc-entry-38"><span class="sectnum">10.1 </span>Standard PDF Fonts</a></p></li>
-<li><p><a class="reference internal" href="#font-embedding" id="toc-entry-39"><span class="sectnum">10.2 </span>Font Embedding</a></p>
+<li><p><a class="reference internal" href="#styles-in-detail" id="toc-entry-31"><span class="sectnum">8.1 </span>Styles in Detail</a></p></li>
+<li><p><a class="reference internal" href="#style-elements" id="toc-entry-32"><span class="sectnum">8.2 </span>Style Elements</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#the-easy-way" id="toc-entry-40"><span class="sectnum">10.2.1 </span>The Easy Way</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#fonty-is-a-true-type-font" id="toc-entry-41"><span class="sectnum">10.2.1.1 </span>Fonty is a True Type font:</a></p></li>
-<li><p><a class="reference internal" href="#fonty-is-a-type-1-font" id="toc-entry-42"><span class="sectnum">10.2.1.2 </span>Fonty is a Type 1 font:</a></p></li>
+<li><p><a class="reference internal" href="#inline-styles" id="toc-entry-33"><span class="sectnum">8.2.1 </span>Inline Styles</a></p></li>
+<li><p><a class="reference internal" href="#lists" id="toc-entry-34"><span class="sectnum">8.2.2 </span>Lists</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#the-harder-way-true-type" id="toc-entry-43"><span class="sectnum">10.2.2 </span>The Harder Way (True Type)</a></p></li>
+<li><p><a class="reference internal" href="#page-layout" id="toc-entry-35"><span class="sectnum">8.3 </span>Page Layout</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#page-setup" id="toc-entry-36"><span class="sectnum">8.3.1 </span>Page Setup</a></p></li>
+<li><p><a class="reference internal" href="#page-templates" id="toc-entry-37"><span class="sectnum">8.3.2 </span>Page Templates</a></p></li>
 </ul>
 </li>
+<li><p><a class="reference internal" href="#font-alias" id="toc-entry-38"><span class="sectnum">8.4 </span>Font Alias</a></p></li>
+<li><p><a class="reference internal" href="#widows-and-orphans" id="toc-entry-39"><span class="sectnum">8.5 </span>Widows and Orphans</a></p></li>
+<li><p><a class="reference internal" href="#table-styles" id="toc-entry-40"><span class="sectnum">8.6 </span>Table Styles</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#raw-directive" id="toc-entry-44"><span class="sectnum">11 </span>Raw Directive</a></p>
+<li><p><a class="reference internal" href="#syntax-highlighting" id="toc-entry-41"><span class="sectnum">9 </span>Syntax Highlighting</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#raw-pdf" id="toc-entry-45"><span class="sectnum">11.1 </span>Raw PDF</a></p></li>
-<li><p><a class="reference internal" href="#page-counters" id="toc-entry-46"><span class="sectnum">11.2 </span>Page Counters</a></p></li>
-<li><p><a class="reference internal" href="#page-breaks" id="toc-entry-47"><span class="sectnum">11.3 </span>Page Breaks</a></p></li>
-<li><p><a class="reference internal" href="#frame-breaks" id="toc-entry-48"><span class="sectnum">11.4 </span>Frame Breaks</a></p></li>
-<li><p><a class="reference internal" href="#page-transitions" id="toc-entry-49"><span class="sectnum">11.5 </span>Page Transitions</a></p></li>
-<li><p><a class="reference internal" href="#text-annotations" id="toc-entry-50"><span class="sectnum">11.6 </span>Text Annotations</a></p></li>
-<li><p><a class="reference internal" href="#raw-html" id="toc-entry-51"><span class="sectnum">11.7 </span>Raw HTML</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#the-counter-role" id="toc-entry-52"><span class="sectnum">12 </span>The counter role</a></p></li>
-<li><p><a class="reference internal" href="#the-version-revision-roles" id="toc-entry-53"><span class="sectnum">13 </span>The version, revision roles</a></p></li>
-<li><p><a class="reference internal" href="#the-oddeven-directive" id="toc-entry-54"><span class="sectnum">14 </span>The oddeven directive</a></p></li>
-<li><p><a class="reference internal" href="#mathematics" id="toc-entry-55"><span class="sectnum">15 </span>Mathematics</a></p></li>
-<li><p><a class="reference internal" href="#hyphenation" id="toc-entry-56"><span class="sectnum">16 </span>Hyphenation</a></p></li>
-<li><p><a class="reference internal" href="#smart-quotes" id="toc-entry-57"><span class="sectnum">17 </span>Smart Quotes</a></p></li>
-<li><p><a class="reference internal" href="#sphinx" id="toc-entry-58"><span class="sectnum">18 </span>Sphinx</a></p></li>
-<li><p><a class="reference internal" href="#extensions" id="toc-entry-59"><span class="sectnum">19 </span>Extensions</a></p>
+<li><p><a class="reference internal" href="#file-inclusion" id="toc-entry-42"><span class="sectnum">9.1 </span>File inclusion</a></p>
 <ul class="auto-toc">
-<li><p><a class="reference internal" href="#preprocess-e-preprocess" id="toc-entry-60"><span class="sectnum">19.1 </span>Preprocess (<span class="docutils literal"><span class="pre">-e</span> preprocess</span>)</a></p></li>
-<li><p><a class="reference internal" href="#dotted-toc-e-dotted-toc" id="toc-entry-61"><span class="sectnum">19.2 </span>Dotted_TOC (<span class="docutils literal"><span class="pre">-e</span> dotted_toc</span>)</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#developers" id="toc-entry-62"><span class="sectnum">20 </span>Developers</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#guidelines" id="toc-entry-63"><span class="sectnum">20.1 </span>Guidelines</a></p></li>
-</ul>
-</li>
-<li><p><a class="reference internal" href="#initial-checkout" id="toc-entry-64"><span class="sectnum">21 </span>Initial checkout</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#git-config" id="toc-entry-65"><span class="sectnum">21.1 </span>Git config</a></p></li>
-<li><p><a class="reference internal" href="#pre-commit" id="toc-entry-66"><span class="sectnum">21.2 </span>Pre-commit</a></p></li>
-<li><p><a class="reference internal" href="#continuous-integration" id="toc-entry-67"><span class="sectnum">21.3 </span>Continuous Integration</a></p></li>
-<li><p><a class="reference internal" href="#running-tests" id="toc-entry-68"><span class="sectnum">21.4 </span>Running tests</a></p>
-<ul class="auto-toc">
-<li><p><a class="reference internal" href="#running-a-single-test" id="toc-entry-69"><span class="sectnum">21.4.1 </span>Running a single test</a></p></li>
-<li><p><a class="reference internal" href="#skipping-tests" id="toc-entry-70"><span class="sectnum">21.4.2 </span>Skipping tests</a></p></li>
+<li><p><a class="reference internal" href="#include-with-boundaries" id="toc-entry-43"><span class="sectnum">9.1.1 </span>Include with Boundaries</a></p></li>
+<li><p><a class="reference internal" href="#options" id="toc-entry-44"><span class="sectnum">9.1.2 </span>Options</a></p></li>
 </ul>
 </li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#licenses" id="toc-entry-71"><span class="sectnum">22 </span>Licenses</a></p></li>
+<li><p><a class="reference internal" href="#fonts" id="toc-entry-45"><span class="sectnum">10 </span>Fonts</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#standard-pdf-fonts" id="toc-entry-46"><span class="sectnum">10.1 </span>Standard PDF Fonts</a></p></li>
+<li><p><a class="reference internal" href="#font-embedding" id="toc-entry-47"><span class="sectnum">10.2 </span>Font Embedding</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#the-easy-way" id="toc-entry-48"><span class="sectnum">10.2.1 </span>The Easy Way</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#fonty-is-a-true-type-font" id="toc-entry-49"><span class="sectnum">10.2.1.1 </span>Fonty is a True Type font:</a></p></li>
+<li><p><a class="reference internal" href="#fonty-is-a-type-1-font" id="toc-entry-50"><span class="sectnum">10.2.1.2 </span>Fonty is a Type 1 font:</a></p></li>
+</ul>
+</li>
+<li><p><a class="reference internal" href="#the-harder-way-true-type" id="toc-entry-51"><span class="sectnum">10.2.2 </span>The Harder Way (True Type)</a></p></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><p><a class="reference internal" href="#raw-directive" id="toc-entry-52"><span class="sectnum">11 </span>Raw Directive</a></p>
+<ul class="auto-toc">
+<li><p><a class="reference internal" href="#raw-pdf" id="toc-entry-53"><span class="sectnum">11.1 </span>Raw PDF</a></p></li>
+<li><p><a class="reference internal" href="#page-counters" id="toc-entry-54"><span class="sectnum">11.2 </span>Page Counters</a></p></li>
+<li><p><a class="reference internal" href="#page-breaks" id="toc-entry-55"><span class="sectnum">11.3 </span>Page Breaks</a></p></li>
+<li><p><a class="reference internal" href="#frame-breaks" id="toc-entry-56"><span class="sectnum">11.4 </span>Frame Breaks</a></p></li>
+<li><p><a class="reference internal" href="#page-transitions" id="toc-entry-57"><span class="sectnum">11.5 </span>Page Transitions</a></p></li>
+<li><p><a class="reference internal" href="#text-annotations" id="toc-entry-58"><span class="sectnum">11.6 </span>Text Annotations</a></p></li>
+<li><p><a class="reference internal" href="#raw-html" id="toc-entry-59"><span class="sectnum">11.7 </span>Raw HTML</a></p></li>
+</ul>
+</li>
+<li><p><a class="reference internal" href="#the-counter-role" id="toc-entry-60"><span class="sectnum">12 </span>The counter role</a></p></li>
+<li><p><a class="reference internal" href="#the-version-revision-roles" id="toc-entry-61"><span class="sectnum">13 </span>The version, revision roles</a></p></li>
+<li><p><a class="reference internal" href="#the-oddeven-directive" id="toc-entry-62"><span class="sectnum">14 </span>The oddeven directive</a></p></li>
+<li><p><a class="reference internal" href="#mathematics" id="toc-entry-63"><span class="sectnum">15 </span>Mathematics</a></p></li>
+<li><p><a class="reference internal" href="#hyphenation" id="toc-entry-64"><span class="sectnum">16 </span>Hyphenation</a></p></li>
+<li><p><a class="reference internal" href="#smart-quotes" id="toc-entry-65"><span class="sectnum">17 </span>Smart Quotes</a></p></li>
+<li><p><a class="reference internal" href="#sphinx" id="toc-entry-66"><span class="sectnum">18 </span>Sphinx</a></p></li>
+<li><p><a class="reference internal" href="#extensions" id="toc-entry-67"><span class="sectnum">19 </span>Extensions</a></p></li>
+<li><p><a class="reference internal" href="#developers" id="toc-entry-68"><span class="sectnum">20 </span>Developers</a></p></li>
+<li><p><a class="reference internal" href="#licenses" id="toc-entry-69"><span class="sectnum">21 </span>Licenses</a></p></li>
 </ul>
 </nav>
 <section id="introduction">
@@ -618,170 +610,190 @@ can be done, let's continue.</p>
 </section>
 <section id="command-line-options">
 <h2><a class="toc-backref" href="#toc-entry-3" role="doc-backlink"><span class="sectnum">2 </span>Command line options</a></h2>
-<dl class="option-list">
-<dt><kbd><span class="option">-h</span>, <span class="option">--help</span></kbd></dt>
-<dd><p>Show this help message and exit</p>
-</dd>
-<dt><kbd><span class="option">--config=<var>FILE</var></span></kbd></dt>
-<dd><p>Config file to use. Default=~/.rst2pdf/config</p>
-</dd>
-<dt><kbd><span class="option">-o <var>FILE</var></span>, <span class="option">--output=<var>FILE</var></span></kbd></dt>
-<dd><p>Write the PDF to FILE</p>
-</dd>
-<dt><kbd><span class="option">-s <var>STYLESHEETS</var></span>, <span class="option">--stylesheets=<var>STYLESHEETS</var></span></kbd></dt>
-<dd><p>A comma-separated list of custom stylesheets.
-Default=&quot;&quot;</p>
-</dd>
-<dt><kbd><span class="option">--stylesheet-path=<var>FOLDERLIST</var></span></kbd></dt>
-<dd><p>A colon-separated list of folders to search for
-stylesheets. Default=&quot;&quot;</p>
-</dd>
-<dt><kbd><span class="option">-c</span>, <span class="option">--compressed</span></kbd></dt>
-<dd><p>Create a compressed PDF. Default=False</p>
-</dd>
-<dt><kbd><span class="option">--print-stylesheet</span></kbd></dt>
-<dd><p>Print the default stylesheet and exit</p>
-</dd>
-<dt><kbd><span class="option">--font-folder=<var>FOLDER</var></span></kbd></dt>
-<dd><p>Search this folder for fonts. (Deprecated)</p>
-</dd>
-<dt><kbd><span class="option">--font-path=<var>FOLDERLIST</var></span></kbd></dt>
-<dd><p>A colon-separated list of folders to search for fonts.
-Default=&quot;&quot;</p>
-</dd>
-<dt><kbd><span class="option">--baseurl=<var>URL</var></span></kbd></dt>
-<dd><p>The base URL for relative URLs.</p>
-</dd>
-<dt><kbd><span class="option">-l <var>LANG</var></span>, <span class="option">--language=<var>LANG</var></span></kbd></dt>
-<dd><p>Language to be used for hyphenation and docutils localization.
-Default=None</p>
-</dd>
-<dt><kbd><span class="option">--header=<var>HEADER</var></span></kbd></dt>
-<dd><p>Page header if not specified in the document.</p>
-</dd>
-<dt><kbd><span class="option">--footer=<var>FOOTER</var></span></kbd></dt>
-<dd><p>Page footer if not specified in the document.</p>
-</dd>
-<dt><kbd><span class="option">--section-header-depth=<var>N</var></span></kbd></dt>
-<dd><p>Sections up to this dept will be used in the header
-and footer's replacement of ###Section###. Default=2</p>
-</dd>
-<dt><kbd><span class="option">--smart-quotes=<var>VALUE</var></span></kbd></dt>
-<dd><p>Try to convert ASCII quotes, ellipsis and dashes to
-the typographically correct equivalent. Default=0</p>
-</dd>
-</dl>
-<p>The possible values are:</p>
-<ol class="arabic simple" start="0">
-<li><p>Suppress all transformations. (Do nothing.)</p></li>
-<li><p>Performs default SmartyPants transformations: quotes (including backticks-style), em-dashes, and ellipses. &quot;--&quot; (dash dash) is used to signify an em-dash; there is no support for en-dashes.</p></li>
-<li><p>Same as --smart-quotes=1, except that it uses the old-school typewriter shorthand for dashes: &quot;--&quot; (dash dash) for en-dashes, &quot;---&quot; (dash dash dash) for em-dashes.</p></li>
-<li><p>Same as --smart-quotes=2, but inverts the shorthand for dashes: &quot;--&quot; (dash dash) for em-dashes, and &quot;---&quot; (dash dash dash) for en-dashes.</p></li>
-</ol>
-<dl class="option-list">
-<dt><kbd><span class="option">--fit-literal-mode=<var>MODE</var></span></kbd></dt>
-<dd><p>What to do when a literal is too wide.
-One of error,overflow,shrink,truncate.
-Default=&quot;shrink&quot;</p>
-</dd>
-<dt><kbd><span class="option">--fit-background-mode=<var>MODE</var></span></kbd></dt>
-<dd><p>How to fit the background image to the page. One of
-scale, scale_width or center. Default=&quot;center&quot;</p>
-</dd>
-<dt><kbd><span class="option">--inline-links</span></kbd></dt>
-<dd><p>Shows target between parenthesis instead of active link</p>
-</dd>
-<dt><kbd><span class="option">--repeat-table-rows</span></kbd></dt>
-<dd><p>Repeats header row for each splitted table</p>
-</dd>
-<dt><kbd><span class="option">--raw-html</span></kbd></dt>
-<dd><p>Support embeddig raw HTML. Default: False</p>
-</dd>
-<dt><kbd><span class="option">-q</span>, <span class="option">--quiet</span></kbd></dt>
-<dd><p>Print less information.</p>
-</dd>
-<dt><kbd><span class="option">-v</span>, <span class="option">--verbose</span></kbd></dt>
-<dd><p>Print debug information.</p>
-</dd>
-<dt><kbd><span class="option">--very-verbose</span></kbd></dt>
-<dd><p>Print even more debug information.</p>
-</dd>
-<dt><kbd><span class="option">--version</span></kbd></dt>
-<dd><p>Print version number and exit.</p>
-</dd>
-<dt><kbd><span class="option">--no-footnote-backlinks</span></kbd></dt>
-<dd><p>Disable footnote backlinks. Default: False</p>
-</dd>
-<dt><kbd><span class="option">--inline-footnotes</span></kbd></dt>
-<dd><p>Show footnotes inline. Default: True</p>
-</dd>
-<dt><kbd><span class="option">--default-dpi=<var>NUMBER</var></span></kbd></dt>
-<dd><p>DPI for objects sized in pixels. Default=300</p>
-</dd>
-<dt><kbd><span class="option">--show-frame-boundary</span></kbd></dt>
-<dd><p>Show frame borders (only useful for debugging).
-Default=False</p>
-</dd>
-<dt><kbd><span class="option">--disable-splittables</span></kbd></dt>
-<dd><p>Don't use splittable flowables in some elements. Only
-try this if you can't process a document any other
-way.</p>
-</dd>
-<dt><kbd><span class="option">-b <var>LEVEL</var></span>, <span class="option">--break-level=<var>LEVEL</var></span></kbd></dt>
-<dd><p>Maximum section level that starts in a new page. Default: 0</p>
-</dd>
-</dl>
-<dl class="simple">
-<dt>--first-page-on-right When using double sided pages, the first page will start</dt>
-<dd><p>on the right hand side. (Book Style)</p>
-</dd>
-</dl>
-<dl class="option-list">
-<dt><kbd><span class="option">--blank-first-page</span></kbd></dt>
-<dd><p>Add a blank page at the beginning of the document.</p>
-</dd>
-<dt><kbd><span class="option">--break-side=<var>VALUE</var></span></kbd></dt>
-<dd><p>How section breaks work. Can be &quot;even&quot;, and sections
-start in an even page,&quot;odd&quot;, and sections start in odd
-pages, or &quot;any&quot; and sections start in the next page,be
-it even or odd. See also the -b option.</p>
-</dd>
-<dt><kbd><span class="option">--date-invariant</span></kbd></dt>
-<dd><p>Don't store the current date in the PDF. Useful mainly
-for the test suite, where we don't want the PDFs to
-change.</p>
-</dd>
-<dt><kbd><span class="option">-e <var>EXTENSIONS</var></span></kbd></dt>
-<dd><p>Alias for --extension-module</p>
-</dd>
-<dt><kbd><span class="option">--extension-module=<var>EXTENSIONS</var></span></kbd></dt>
-<dd><p>Add a helper extension module to this invocation of
-rst2pdf (module must end in .py and be on the python
-path)</p>
-</dd>
-<dt><kbd><span class="option">--custom-cover=<var>FILE</var></span></kbd></dt>
-<dd><p>Template file used for the cover page. Default:
-cover.tmpl</p>
-</dd>
-<dt><kbd><span class="option">--use-floating-images</span></kbd></dt>
-<dd><p>Makes images with :align: attribute work more like in
-rst2html. Default: False</p>
-</dd>
-<dt><kbd><span class="option">--use-numbered-links</span></kbd></dt>
-<dd><p>When using numbered sections, adds the numbers to all
-links referring to the section headers. Default: False</p>
-</dd>
-<dt><kbd><span class="option">--strip-elements-with-class=<var>CLASS</var></span></kbd></dt>
-<dd><p>Remove elements with this CLASS from the output. Can
-be used multiple times.</p>
-</dd>
-<dt><kbd><span class="option">--record-dependencies=<var>FILE</var></span></kbd></dt>
-<dd><p>Write output file dependencies to FILE.</p>
-</dd>
-</dl>
+<p>Use the following options to control the output of <cite>rst2pdf</cite> on the command line.</p>
+<section id="general-options">
+<h3><a class="toc-backref" href="#toc-entry-4" role="doc-backlink"><span class="sectnum">2.1 </span>General Options</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">-h,</span> <span class="pre">--help</span></span></p></td>
+<td><p>Show the help message and exit.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--version</span></span></p></td>
+<td><p>Print the version number and exit.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">-q,</span> <span class="pre">--quiet</span></span></p></td>
+<td><p>Print less information.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">-v,</span> <span class="pre">--verbose</span></span></p></td>
+<td><p>Print debug information.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--very-verbose</span></span></p></td>
+<td><p>Print even more debug information.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="file-and-configuration">
+<h3><a class="toc-backref" href="#toc-entry-5" role="doc-backlink"><span class="sectnum">2.2 </span>File and Configuration</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">--config=FILE</span></span></p></td>
+<td><p>Config file to use. Default: <span class="docutils literal"><span class="pre">~/.rst2pdf/config</span></span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">-o</span> FILE, <span class="pre">--output=FILE</span></span></p></td>
+<td><p>Write the PDF to <span class="docutils literal">FILE</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--record-dependencies=FILE</span></span></p></td>
+<td><p>Write output file dependencies to <span class="docutils literal">FILE</span>.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="styling-options">
+<h3><a class="toc-backref" href="#toc-entry-6" role="doc-backlink"><span class="sectnum">2.3 </span>Styling Options</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">-s</span> STYLESHEETS, <span class="pre">--stylesheets=STYLESHEETS</span></span></p></td>
+<td><p>A comma-separated list of custom stylesheets. Default: <span class="docutils literal">&quot;&quot;</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--stylesheet-path=FOLDERLIST</span></span></p></td>
+<td><p>A colon-separated list of folders to search for stylesheets. Default: <span class="docutils literal">&quot;&quot;</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--print-stylesheet</span></span></p></td>
+<td><p>Print the default stylesheet and exit.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--font-path=FOLDERLIST</span></span></p></td>
+<td><p>A colon-separated list of folders to search for fonts. Default: <span class="docutils literal">&quot;&quot;</span>.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="pdf-options">
+<h3><a class="toc-backref" href="#toc-entry-7" role="doc-backlink"><span class="sectnum">2.4 </span>PDF Options</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">-c,</span> <span class="pre">--compressed</span></span></p></td>
+<td><p>Create a compressed PDF. Default: <span class="docutils literal">False</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--baseurl=URL</span></span></p></td>
+<td><p>The base URL for relative URLs.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--header=HEADER</span></span></p></td>
+<td><p>Page header if not specified in the document.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--footer=FOOTER</span></span></p></td>
+<td><p>Page footer if not specified in the document.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--first-page-on-right</span></span></p></td>
+<td><p>When using double-sided pages, the first page will start on the right-hand side (Book Style).</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--blank-first-page</span></span></p></td>
+<td><p>Add a blank page at the beginning of the document.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--custom-cover=FILE</span></span></p></td>
+<td><p>Template file used for the cover page. Default: <span class="docutils literal">cover.tmpl</span>.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="formatting-options">
+<h3><a class="toc-backref" href="#toc-entry-8" role="doc-backlink"><span class="sectnum">2.5 </span>Formatting Options</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">--section-header-depth=N</span></span></p></td>
+<td><p>Sections up to this depth will be used in the header and footer's replacement of <span class="docutils literal"><span class="pre">###Section###</span></span>. Default: <span class="docutils literal">2</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--smart-quotes=VALUE</span></span></p></td>
+<td><p>Convert ASCII quotes, ellipses, and dashes to typographically correct equivalents. Default: <span class="docutils literal">0</span>.</p>
+<p>Accepted values:</p>
+<ul class="simple">
+<li><p><span class="docutils literal">0</span>: Suppress all transformations.</p></li>
+<li><p><span class="docutils literal">1</span>: Default transformations for quotes, em-dashes, and ellipses.</p></li>
+<li><p><span class="docutils literal">2</span>: Use typewriter shorthand for dashes.</p></li>
+<li><p><span class="docutils literal">3</span>: Invert shorthand for dashes.</p></li>
+</ul>
+</td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--fit-literal-mode=MODE</span></span></p></td>
+<td><p>Handle literals that are too wide. Options: <span class="docutils literal">error</span>, <span class="docutils literal">overflow</span>, <span class="docutils literal">shrink</span>, <span class="docutils literal">truncate</span>. Default: <span class="docutils literal">shrink</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--fit-background-mode=MODE</span></span></p></td>
+<td><p>Fit the background image to the page. Options: <span class="docutils literal">scale</span>, <span class="docutils literal">scale_width</span>, <span class="docutils literal">center</span>. Default: <span class="docutils literal">center</span>.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="miscellaneous-options">
+<h3><a class="toc-backref" href="#toc-entry-9" role="doc-backlink"><span class="sectnum">2.6 </span>Miscellaneous Options</a></h3>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal"><span class="pre">-e</span> EXTENSIONS, <span class="pre">--extension-module=EXTENSIONS</span></span></p></td>
+<td><p>Add a helper extension module (must end in <span class="docutils literal">.py</span> and be on the Python path).</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--inline-links</span></span></p></td>
+<td><p>Show targets in parentheses instead of active links.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--repeat-table-rows</span></span></p></td>
+<td><p>Repeat the header row for each split table.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--raw-html</span></span></p></td>
+<td><p>Support embedding raw HTML. Default: <span class="docutils literal">False</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--no-footnote-backlinks</span></span></p></td>
+<td><p>Disable footnote backlinks. Default: <span class="docutils literal">False</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--inline-footnotes</span></span></p></td>
+<td><p>Show footnotes inline. Default: <span class="docutils literal">True</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--default-dpi=NUMBER</span></span></p></td>
+<td><p>DPI for objects sized in pixels. Default: <span class="docutils literal">300</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--show-frame-boundary</span></span></p></td>
+<td><p>Show frame borders (useful for debugging). Default: <span class="docutils literal">False</span>.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--disable-splittables</span></span></p></td>
+<td><p>Disable splittable flowables in some elements. Useful if a document cannot otherwise be processed.</p></td>
+</tr>
+<tr><td><p><span class="docutils literal"><span class="pre">--break-side=VALUE</span></span></p></td>
+<td><p>Section break behavior. Options: <span class="docutils literal">even</span>, <span class="docutils literal">odd</span>, <span class="docutils literal">any</span>.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
 </section>
 <section id="configuration-file">
-<h2><a class="toc-backref" href="#toc-entry-4" role="doc-backlink"><span class="sectnum">3 </span>Configuration File</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10" role="doc-backlink"><span class="sectnum">3 </span>Configuration File</a></h2>
+<p>The configuration file uses an <strong>INI-style</strong> format with sections and key-value pairs. Comments are prefixed with <span class="docutils literal">#</span>.</p>
 <p>Since version 0.8, rst2pdf will read (if it is available) configuration files in
 <span class="docutils literal">/etc/rst2pdf.conf</span> and <span class="docutils literal"><span class="pre">~/.rst2pdf/config</span></span>.</p>
 <p>The user's file at <span class="docutils literal"><span class="pre">~/.rst2pdf/config</span></span> will have priority over the system's at
@@ -794,102 +806,122 @@ systems. if you are using rst2pdf in other systems, please contact me and
 tell me where the system-wide config file should be.</p>
 </aside>
 </aside>
-<p>Here's an example file showing some of the currently available options:</p>
+<section id="configuration-options">
+<h3><a class="toc-backref" href="#toc-entry-11" role="doc-backlink"><span class="sectnum">3.1 </span>Configuration Options</a></h3>
+<p>The table below provides detailed descriptions of the available configuration options.</p>
+<table>
+<thead>
+<tr><th class="head"><p>Option</p></th>
+<th class="head"><p>Description</p></th>
+<th class="head"><p>Default Value</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p><span class="docutils literal">stylesheets</span></p></td>
+<td><p>Comma-separated list of custom stylesheets.</p></td>
+<td><p><span class="docutils literal">&quot;&quot;</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">compressed</span></p></td>
+<td><p>Generate a compressed PDF. Use <span class="docutils literal">true</span>/<span class="docutils literal">false</span> or <span class="docutils literal">1</span>/<span class="docutils literal">0</span>.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">font_path</span></p></td>
+<td><p>Colon-separated list of folders to search for fonts.</p></td>
+<td><p><span class="docutils literal">&quot;&quot;</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">stylesheet_path</span></p></td>
+<td><p>Colon-separated list of folders to search for stylesheets.</p></td>
+<td><p><span class="docutils literal">&quot;&quot;</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">language</span></p></td>
+<td><p>Language for hyphenation and localization.</p></td>
+<td><p><span class="docutils literal">en_US</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">header</span></p></td>
+<td><p>Default page header. Use <span class="docutils literal">null</span> for no header.</p></td>
+<td><p><span class="docutils literal">null</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">footer</span></p></td>
+<td><p>Default page footer. Use <span class="docutils literal">null</span> for no footer.</p></td>
+<td><p><span class="docutils literal">null</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">fit_mode</span></p></td>
+<td><p>Handle oversized literal blocks. Options: <span class="docutils literal">shrink</span>, <span class="docutils literal">truncate</span>, <span class="docutils literal">overflow</span>.</p></td>
+<td><p><span class="docutils literal">shrink</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">fit_background_mode</span></p></td>
+<td><p>Adjust background images. Options: <span class="docutils literal">scale</span>, <span class="docutils literal">center</span>.</p></td>
+<td><p><span class="docutils literal">center</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">break_level</span></p></td>
+<td><p>Maximum heading level that starts on a new page.</p></td>
+<td><p><span class="docutils literal">0</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">break_side</span></p></td>
+<td><p>Section break alignment. Options: <span class="docutils literal">even</span>, <span class="docutils literal">odd</span>, <span class="docutils literal">any</span>.</p></td>
+<td><p><span class="docutils literal">any</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">blank_first_page</span></p></td>
+<td><p>Add a blank page at the start of the document.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">first_page_even</span></p></td>
+<td><p>Treat the first page as even.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">smartquotes</span></p></td>
+<td><p>Configure smart quotes transformation.</p>
+<p>Accepted values:</p>
+<ul class="simple">
+<li><p><span class="docutils literal">0</span>: Suppress all transformations.</p></li>
+<li><p><span class="docutils literal">1</span>: Default transformations for quotes, em-dashes, and ellipses.</p></li>
+<li><p><span class="docutils literal">2</span>: Use typewriter shorthand for dashes.</p></li>
+<li><p><span class="docutils literal">3</span>: Invert shorthand for dashes.</p></li>
+</ul>
+</td>
+<td><p><span class="docutils literal">0</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">footnote_backlinks</span></p></td>
+<td><p>Enable footnote backlinks.</p></td>
+<td><p><span class="docutils literal">true</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">inline_footnotes</span></p></td>
+<td><p>Show footnotes inline.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">custom_cover</span></p></td>
+<td><p>Template file for the cover page.</p></td>
+<td><p><span class="docutils literal">cover.tmpl</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">floating_images</span></p></td>
+<td><p>Enable floating images for alignment.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+<tr><td><p><span class="docutils literal">raw_html</span></p></td>
+<td><p>Enable support for the <span class="docutils literal">..raw:: html</span> directive.</p></td>
+<td><p><span class="docutils literal">false</span></p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="example-configuration-file">
+<h3><a class="toc-backref" href="#toc-entry-12" role="doc-backlink"><span class="sectnum">3.2 </span>Example Configuration File</a></h3>
+<p>Here's an example configuration file showing the expected format:</p>
 <pre class="code ini literal-block"><code><span class="pygments-c1"># This is an example config file. Modify and place in ~/.rst2pdf/config</span><span class="pygments-w">
 
 </span><span class="pygments-k">[general]</span><span class="pygments-w">
-</span><span class="pygments-c1"># A comma-separated list of custom stylesheets. Example:</span><span class="pygments-w">
-</span><span class="pygments-c1"># stylesheets=&quot;fruity.json,a4paper.json,verasans.json&quot;</span><span class="pygments-w">
+</span><span class="pygments-na">stylesheets</span><span class="pygments-o">=</span><span class="pygments-s">&quot;fruity.json,a4paper.json,verasans.json&quot;</span><span class="pygments-w">
 
-</span><span class="pygments-na">stylesheets</span><span class="pygments-o">=</span><span class="pygments-s">&quot;&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Create a compressed PDF</span><span class="pygments-w">
-</span><span class="pygments-c1"># Use true/false (lower case) or 1/0</span><span class="pygments-w">
-</span><span class="pygments-na">compressed</span><span class="pygments-o">=</span><span class="pygments-s">false</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># A colon-separated list of folders to search for fonts. Example:</span><span class="pygments-w">
-</span><span class="pygments-c1"># font_path=&quot;/usr/share/fonts:/usr/share/texmf-dist/fonts/&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-na">font_path</span><span class="pygments-o">=</span><span class="pygments-s">&quot;&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># A colon-separated list of folders to search for stylesheets. Example:</span><span class="pygments-w">
-</span><span class="pygments-c1"># stylesheet_path=&quot;~/styles:/usr/share/styles&quot;</span><span class="pygments-w">
-</span><span class="pygments-na">stylesheet_path</span><span class="pygments-o">=</span><span class="pygments-s">&quot;&quot;</span><span class="pygments-w">
+</span><span class="pygments-c1"># Folders to search for stylesheets.</span><span class="pygments-w">
+</span><span class="pygments-na">stylesheet_path</span><span class="pygments-o">=</span><span class="pygments-s">&quot;~/styles:/usr/share/styles&quot;</span><span class="pygments-w">
 
 </span><span class="pygments-c1"># Language to be used for hyphenation support</span><span class="pygments-w">
-
 </span><span class="pygments-na">language</span><span class="pygments-o">=</span><span class="pygments-s">&quot;en_US&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Default page header and footer</span><span class="pygments-w">
-</span><span class="pygments-na">header</span><span class="pygments-o">=</span><span class="pygments-s">null</span><span class="pygments-w">
-</span><span class="pygments-na">footer</span><span class="pygments-o">=</span><span class="pygments-s">null</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># What to do if a literal block is too large. Can be</span><span class="pygments-w">
-</span><span class="pygments-c1"># shrink/truncate/overflow</span><span class="pygments-w">
-
-</span><span class="pygments-na">fit_mode</span><span class="pygments-o">=</span><span class="pygments-s">&quot;shrink&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># How to adjust the background image to the page.</span><span class="pygments-w">
-</span><span class="pygments-c1"># Can be: &quot;scale&quot; and &quot;center&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-na">fit_background_mode</span><span class="pygments-o">=</span><span class="pygments-s">&quot;center&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># What is the maximum level of heading that starts in a new page.</span><span class="pygments-w">
-</span><span class="pygments-c1"># 0 means no level starts in a new page.</span><span class="pygments-w">
-
-</span><span class="pygments-na">break_level</span><span class="pygments-o">=</span><span class="pygments-s">0</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># How section breaks work. Can be &quot;even&quot;, and sections start in an</span><span class="pygments-w">
-</span><span class="pygments-c1"># even page, &quot;odd&quot;, and sections start in odd pages, or &quot;any&quot; and</span><span class="pygments-w">
-</span><span class="pygments-c1"># sections start in the next page, be it even or odd.</span><span class="pygments-w">
-
-</span><span class="pygments-na">break_side</span><span class="pygments-o">=</span><span class="pygments-s">&quot;any&quot;</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Add a blank page at the beginning of the document</span><span class="pygments-w">
-
-</span><span class="pygments-na">blank_first_page</span><span class="pygments-o">=</span><span class="pygments-s">false</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Treat the first page as even (default false, treat it as odd)</span><span class="pygments-w">
-
-</span><span class="pygments-na">first_page_even</span><span class="pygments-o">=</span><span class="pygments-s">false</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Smart quotes.</span><span class="pygments-w">
-</span><span class="pygments-c1"># 0:  Suppress  all  transformations. (Do nothing.)</span><span class="pygments-w">
-</span><span class="pygments-c1"># 1: Performs default SmartyPants transformations: quotes (including ‘‘backticks''</span><span class="pygments-w">
-</span><span class="pygments-c1"># -style), em-dashes, and ellipses. &quot;--&quot; (dash dash) is used to signify an em-dash;</span><span class="pygments-w">
-</span><span class="pygments-c1"># there is no support for en-dashes.</span><span class="pygments-w">
-</span><span class="pygments-c1"># 2:  Same as 1, except that it uses the old-school typewriter shorthand for</span><span class="pygments-w">
-</span><span class="pygments-c1"># dashes: &quot;--&quot; (dash dash) for en-dashes, &quot;---&quot; (dash dash dash) for em-dashes.</span><span class="pygments-w">
-</span><span class="pygments-c1"># 3: Same as 2, but inverts the shorthand for dashes: &quot;--&quot; (dash dash) for</span><span class="pygments-w">
-</span><span class="pygments-c1"># em-dashes,  and &quot;---&quot; (dash dash dash) for en-dashes.</span><span class="pygments-w">
-
-</span><span class="pygments-na">smartquotes</span><span class="pygments-o">=</span><span class="pygments-s">0</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Footnote backlinks enabled or not (default: enabled)</span><span class="pygments-w">
-
-</span><span class="pygments-na">footnote_backlinks</span><span class="pygments-o">=</span><span class="pygments-s">true</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Show footnotes inline instead of at the end of the document</span><span class="pygments-w">
-
-</span><span class="pygments-na">inline_footnotes</span><span class="pygments-o">=</span><span class="pygments-s">false</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Cover page template.</span><span class="pygments-w">
-</span><span class="pygments-c1"># It will be searched in the document's folder, in ~/.rst2pdf/templates and</span><span class="pygments-w">
-</span><span class="pygments-c1"># in the templates subfolder of the package folder</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># custom_cover = cover.tmpl</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Use floating images.</span><span class="pygments-w">
-</span><span class="pygments-c1"># Makes the behaviour of images with the :align: attribute more like rst2html's</span><span class="pygments-w">
-
-</span><span class="pygments-na">floating_images</span><span class="pygments-w"> </span><span class="pygments-o">=</span><span class="pygments-w"> </span><span class="pygments-s">false</span><span class="pygments-w">
-
-</span><span class="pygments-c1"># Support the ..raw:: html directive</span><span class="pygments-w">
-</span><span class="pygments-na">raw_html</span><span class="pygments-w"> </span><span class="pygments-o">=</span><span class="pygments-w"> </span><span class="pygments-s">false</span><span class="pygments-w">
 </span></code></pre>
 </section>
+</section>
 <section id="pipe-usage">
-<h2><a class="toc-backref" href="#toc-entry-5" role="doc-backlink"><span class="sectnum">4 </span>Pipe usage</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-13" role="doc-backlink"><span class="sectnum">4 </span>Pipe usage</a></h2>
 <p>If no input nor output are provided, <span class="docutils literal">stdin</span> and <span class="docutils literal">stdout</span> will be used
 respectively.</p>
 <p>You may want to use rst2pdf in a linux pipe as such:</p>
@@ -902,9 +934,9 @@ respectively.</p>
 <pre class="literal-block">rst2pdf -o - readme.txt &gt; output.pdf</pre>
 </section>
 <section id="images">
-<h2><a class="toc-backref" href="#toc-entry-6" role="doc-backlink"><span class="sectnum">5 </span>Images</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-14" role="doc-backlink"><span class="sectnum">5 </span>Images</a></h2>
 <section id="inline">
-<h3><a class="toc-backref" href="#toc-entry-7" role="doc-backlink"><span class="sectnum">5.1 </span>Inline</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-15" role="doc-backlink"><span class="sectnum">5.1 </span>Inline</a></h3>
 <p>You can insert images in the middle of your text like this:</p>
 <pre class="literal-block">This |biohazard| means you have to run.
 
@@ -912,7 +944,7 @@ respectively.</p>
 <p>This <img alt="biohazard" src="assets/biohazard.png" /> means you have to run.</p>
 </section>
 <section id="supported-image-types">
-<h3><a class="toc-backref" href="#toc-entry-8" role="doc-backlink"><span class="sectnum">5.2 </span>Supported Image Types</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-16" role="doc-backlink"><span class="sectnum">5.2 </span>Supported Image Types</a></h3>
 <p>For raster images, rst2pdf supports anything PIL (The Python Imaging Library)
 supports.  The exact list of supported formats varies according to your PIL
 version and system.</p>
@@ -933,7 +965,7 @@ won't go away.</p>
 </aside>
 </section>
 <section id="image-size">
-<h3><a class="toc-backref" href="#toc-entry-9" role="doc-backlink"><span class="sectnum">5.3 </span>Image Size</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-17" role="doc-backlink"><span class="sectnum">5.3 </span>Image Size</a></h3>
 <p>PDFs are meant to reflect paper. A PDF has a specific size in centimeters or
 inches.</p>
 <p>Images usually are measured in pixels, which are meaningless in a PDF. To
@@ -989,11 +1021,11 @@ whatever you choose with the <span class="docutils literal"><span class="pre">--
 </section>
 </section>
 <section id="styling-restructuredtext">
-<h2><a class="toc-backref" href="#toc-entry-10" role="doc-backlink"><span class="sectnum">6 </span>Styling ReStructuredText</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-18" role="doc-backlink"><span class="sectnum">6 </span>Styling ReStructuredText</a></h2>
 <p>For well-formatted and consistent PDFs, the best starting point is well-formatted and consistent markup. There are some excellent references for ReStructuredText which we won't reproduce here but they are highly recommended as a starting point for working with rst2pdf.</p>
 <p>In general, applying a stylesheet to a structured document will output a decent PDF with minimum fuss. That said, there are plenty of customisation and styling options available so read on if that sounds interesting.</p>
 <section id="applying-styles">
-<h3><a class="toc-backref" href="#toc-entry-11" role="doc-backlink"><span class="sectnum">6.1 </span>Applying Styles</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-19" role="doc-backlink"><span class="sectnum">6.1 </span>Applying Styles</a></h3>
 <p>rst2pdf applies a default set of styles to the document. This default set can be viewed using <span class="docutils literal">rst2pdf <span class="pre">--print-stylesheet</span></span> which prints outh <span class="docutils literal">rst2pdf/styles/styles.yaml</span>.</p>
 <p>Each subsequent style within each style sheet file specified the <span class="docutils literal"><span class="pre">--stylesheets</span></span> CLI parameter is then registered in the the list of known styles known to rst2pdf. If the name of the style is already known, then the attributes specified in the style are applied &quot;on top&quot; of the already registered style.</p>
 <p>rst2pdf will then resolve the <span class="docutils literal">parent</span> style, which is why the order of inclusion matters per-style-name, not globally. That is, if you set the color of <span class="docutils literal">bodytext</span> first in a file and then set the color of <span class="docutils literal">normal</span> in a subsequent file, then the color you have set for <span class="docutils literal">bodytext</span> will be the color used for paragraphs (unless overridden by a <span class="docutils literal">class</span> directive. Further information on cereating stylesheet files is available in <a class="reference internal" href="#creating-stylesheets">Creating Stylesheets</a>.</p>
@@ -1016,7 +1048,7 @@ I like color :redtext:`red`.</pre>
 <p>For more information about this, please check the rST docs, and for style information check the section in this manual on <a class="reference internal" href="#inline-styles">inline styles</a>.</p>
 </section>
 <section id="headers-and-footers">
-<h3><a class="toc-backref" href="#toc-entry-12" role="doc-backlink"><span class="sectnum">6.2 </span>Headers and Footers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-20" role="doc-backlink"><span class="sectnum">6.2 </span>Headers and Footers</a></h3>
 <p>rST supports headers and footers, using the header and footer directive:</p>
 <pre class="literal-block">.. header::
 
@@ -1050,7 +1082,7 @@ via <cite>command line options</cite> or the <a class="reference internal" href=
 page, check <a class="reference internal" href="#the-oddeven-directive">The oddeven directive</a></p>
 </section>
 <section id="footnotes">
-<h3><a class="toc-backref" href="#toc-entry-13" role="doc-backlink"><span class="sectnum">6.3 </span>Footnotes</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-21" role="doc-backlink"><span class="sectnum">6.3 </span>Footnotes</a></h3>
 <p>Currently rst2pdf doesn't support real footnotes, and converts them to endnotes.
 There is a real complicated technical reason for this: I can't figure out a
 clean way to do it right.</p>
@@ -1061,7 +1093,7 @@ notes.)</p>
 </section>
 </section>
 <section id="customizing-pdf-output">
-<h2><a class="toc-backref" href="#toc-entry-14" role="doc-backlink"><span class="sectnum">7 </span>Customizing PDF Output</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22" role="doc-backlink"><span class="sectnum">7 </span>Customizing PDF Output</a></h2>
 <p>Stylesheets are used to control many aspects of the PDF output.</p>
 <blockquote>
 <ul class="simple">
@@ -1072,7 +1104,7 @@ notes.)</p>
 </blockquote>
 <p>The stylesheets use a YAML format (JSON is also supported). Older versions of this tool used an RSON format; this is also still supported but we recommend you check the section on <cite>migrating to yaml stylesheets</cite> and update them (it's painless!)</p>
 <section id="using-stylesheets">
-<h3><a class="toc-backref" href="#toc-entry-15" role="doc-backlink"><span class="sectnum">7.1 </span>Using Stylesheets</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-23" role="doc-backlink"><span class="sectnum">7.1 </span>Using Stylesheets</a></h3>
 <p>Specify a stylesheet to use with -s:</p>
 <pre class="literal-block">rst2pdf mydoc.rst -s mystyles</pre>
 <p>Often it makes sense to specify multiple stylesheets, for example to set the page size, the main styles, and some syntax highlighting. In that case, use comma-separated values:</p>
@@ -1088,7 +1120,7 @@ notes.)</p>
 </ul>
 </section>
 <section id="included-stylesheets">
-<h3><a class="toc-backref" href="#toc-entry-16" role="doc-backlink"><span class="sectnum">7.2 </span>Included StyleSheets</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24" role="doc-backlink"><span class="sectnum">7.2 </span>Included StyleSheets</a></h3>
 <p>To make some of the more common adjustments easier, rst2pdf includes a
 collection of stylesheets you can use:</p>
 <dl>
@@ -1127,13 +1159,13 @@ Serif (Arial)</p></li>
 <pre class="literal-block">rst2pdf mydoc.txt -s twocolumn,serif,murphy,legal</pre>
 </section>
 <section id="default-stylesheet">
-<h3><a class="toc-backref" href="#toc-entry-17" role="doc-backlink"><span class="sectnum">7.3 </span>Default Stylesheet</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25" role="doc-backlink"><span class="sectnum">7.3 </span>Default Stylesheet</a></h3>
 <p>You can make rst2pdf print the default stylesheet:</p>
 <pre class="literal-block">rst2pdf --print-stylesheet</pre>
 <p>This makes an excellent starting point for creating a stylesheet. The default one is always included by default, so only the values that should be changed need to be included in the new stylesheet.</p>
 </section>
 <section id="migrating-stylesheet-format">
-<h3><a class="toc-backref" href="#toc-entry-18" role="doc-backlink"><span class="sectnum">7.4 </span>Migrating Stylesheet Format</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26" role="doc-backlink"><span class="sectnum">7.4 </span>Migrating Stylesheet Format</a></h3>
 <p>Historically, (version 0.98 and earlier) rst2pdf had support for JSON and RSON stylesheets. Those stylesheets should still work if you are still using them but a warning will be produced:</p>
 <pre class="literal-block">[WARNING] styles.py:617 Stylesheet &quot;./example.style&quot; in outdated format, recommend converting to YAML</pre>
 <p>To update your stylesheet, use the <span class="docutils literal">rst2pdf.style2yaml</span> utility:</p>
@@ -1141,12 +1173,12 @@ Serif (Arial)</p></li>
 <p>The command also accepts a list of paths, or wildcards, and by default will output the new stylesheet(s) to stdout. To write them to files instead, use the <span class="docutils literal"><span class="pre">--save</span></span> flag with the command above.</p>
 </section>
 <section id="migrating-to-the-new-default-stylesheet">
-<h3><a class="toc-backref" href="#toc-entry-19" role="doc-backlink"><span class="sectnum">7.5 </span>Migrating to the New Default Stylesheet</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-27" role="doc-backlink"><span class="sectnum">7.5 </span>Migrating to the New Default Stylesheet</a></h3>
 <p>Historically (version 0.98 and earlier), rst2pdf used a different default style sheet. The updated default style file provide a more modern look to rst2pdf documents. To do this, it updates various spacing, margins and fonts. It also updates page template and font alias names and so you will need to make adjustments to derived style files.</p>
 <p>Until you make these adjustments, you can use the historical default style sheet using by adding the <span class="docutils literal"><span class="pre">rst2pdf-0-9</span></span> style using the <span class="docutils literal"><span class="pre">-s</span></span> command line switch. For example:</p>
 <pre class="literal-block">rst2pdf mydoc.rst -s rst2pdf-0-9,mystyle.yaml</pre>
 <section id="updated-font-alias-names">
-<h4><a class="toc-backref" href="#toc-entry-20" role="doc-backlink"><span class="sectnum">7.5.1 </span>Updated Font Alias Names</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-28" role="doc-backlink"><span class="sectnum">7.5.1 </span>Updated Font Alias Names</a></h4>
 <p>The font aliases used for the standard fonts have changed from those used in the historical default style sheeet. As such, you will need to update to the new names in any derivative style files.</p>
 <p>This table shows the old name and the equivalent new name:</p>
 <table>
@@ -1199,7 +1231,7 @@ Serif (Arial)</p></li>
 </table>
 </section>
 <section id="updated-pate-template-names">
-<h4><a class="toc-backref" href="#toc-entry-21" role="doc-backlink"><span class="sectnum">7.5.2 </span>Updated Pate Template Names</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-29" role="doc-backlink"><span class="sectnum">7.5.2 </span>Updated Pate Template Names</a></h4>
 <p>The page template names used in the new default style sheet are different from the historical default style sheeet. As such, you will need to update to the new names in any derivative style files.</p>
 <p>This table shows the old name and the equivalent new name:</p>
 <table>
@@ -1234,7 +1266,7 @@ Serif (Arial)</p></li>
 </section>
 </section>
 <section id="creating-stylesheets">
-<h2><a class="toc-backref" href="#toc-entry-22" role="doc-backlink"><span class="sectnum">8 </span>Creating Stylesheets</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-30" role="doc-backlink"><span class="sectnum">8 </span>Creating Stylesheets</a></h2>
 <p>The stylesheets are YAML-formatted and give control over many aspects of how the PDF is rendered. The main aspects are the styles of the elements, the page setup and templates, and the fonts to use . These are described in the following sections.</p>
 <p>Only the settings that you want to change need to be included so for example, this would be a valid stylesheet:</p>
 <pre class="code yaml literal-block"><code><span class="pygments-nt">pageSetup</span><span class="pygments-p">:</span><span class="pygments-w">
@@ -1246,7 +1278,7 @@ Serif (Arial)</p></li>
     </span><span class="pygments-nt">fontSize</span><span class="pygments-p">:</span><span class="pygments-w"> </span><span class="pygments-l-Scalar-Plain">14</span><span class="pygments-w">
 </span></code></pre>
 <section id="styles-in-detail">
-<h3><a class="toc-backref" href="#toc-entry-23" role="doc-backlink"><span class="sectnum">8.1 </span>Styles in Detail</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-31" role="doc-backlink"><span class="sectnum">8.1 </span>Styles in Detail</a></h3>
 <p>At the top level there is a bit of an outlier: <span class="docutils literal">linkColor</span>. You can specify any color name or a hex value:</p>
 <pre class="literal-block">linkColor: #330099</pre>
 <p>Most of the other elements for colours and formatting are in the <cite>styles</cite> section.</p>
@@ -1279,7 +1311,7 @@ will print a warning and use <span class="docutils literal">bodytext</span> inst
 <span class="docutils literal">styleB</span>, <span class="docutils literal">styleA</span> should be earlier in the stylesheet.</p>
 </section>
 <section id="style-elements">
-<h3><a class="toc-backref" href="#toc-entry-24" role="doc-backlink"><span class="sectnum">8.2 </span>Style Elements</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-32" role="doc-backlink"><span class="sectnum">8.2 </span>Style Elements</a></h3>
 <p>Within the <span class="docutils literal">styles</span> element, it is possible to configure each element type.
 The following section lays out the known options and examples of how to use them.
 (This list is known to be incomplete, we're working on it and accept any
@@ -1388,7 +1420,7 @@ margin in the center of a two-page spread.  This value is added to the left marg
 </span><span class="pygments-nt">margin-gutter</span><span class="pygments-p">:</span><span class="pygments-w"> </span><span class="pygments-l-Scalar-Plain">0cm</span><span class="pygments-w">
 </span></code></pre>
 <section id="inline-styles">
-<h4><a class="toc-backref" href="#toc-entry-25" role="doc-backlink"><span class="sectnum">8.2.1 </span>Inline Styles</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-33" role="doc-backlink"><span class="sectnum">8.2.1 </span>Inline Styles</a></h4>
 <p>The following are the only attributes that work on styles when used for
 interpreted roles (inline styles):</p>
 <ul class="simple">
@@ -1399,7 +1431,7 @@ interpreted roles (inline styles):</p>
 </ul>
 </section>
 <section id="lists">
-<h4><a class="toc-backref" href="#toc-entry-26" role="doc-backlink"><span class="sectnum">8.2.2 </span>Lists</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-34" role="doc-backlink"><span class="sectnum">8.2.2 </span>Lists</a></h4>
 <p>Styling lists is mostly a matter of spacing and indentation.</p>
 <p>The space before and after a list is taken from the <span class="docutils literal"><span class="pre">item-list</span></span> and
 <span class="docutils literal"><span class="pre">bullet-list</span></span> styles:</p>
@@ -1436,10 +1468,10 @@ after the last items.</p>
 </section>
 </section>
 <section id="page-layout">
-<h3><a class="toc-backref" href="#toc-entry-27" role="doc-backlink"><span class="sectnum">8.3 </span>Page Layout</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-35" role="doc-backlink"><span class="sectnum">8.3 </span>Page Layout</a></h3>
 <p>There are some layouts available as standard stylesheets, but it is likely that you will also want to describe your own templates.</p>
 <section id="page-setup">
-<h4><a class="toc-backref" href="#toc-entry-28" role="doc-backlink"><span class="sectnum">8.3.1 </span>Page Setup</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-36" role="doc-backlink"><span class="sectnum">8.3.1 </span>Page Setup</a></h4>
 <p>In your stylesheet, the <span class="docutils literal">pageSetup</span> element controls your page layout.</p>
 <p>Here's the default stylesheet's element:</p>
 <pre class="literal-block">pageSetup:
@@ -1466,7 +1498,7 @@ after the last items.</p>
 width/height ignored.</p>
 </section>
 <section id="page-templates">
-<h4><a class="toc-backref" href="#toc-entry-29" role="doc-backlink"><span class="sectnum">8.3.2 </span>Page Templates</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-37" role="doc-backlink"><span class="sectnum">8.3.2 </span>Page Templates</a></h4>
 <p>By default, your document will have a single column of text covering the space
 between the margins. You can change that, though, in fact you can do so even in
 the middle of your document!</p>
@@ -1534,7 +1566,7 @@ option, so use with caution.</p>
 </section>
 </section>
 <section id="font-alias">
-<h3><a class="toc-backref" href="#toc-entry-30" role="doc-backlink"><span class="sectnum">8.4 </span>Font Alias</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-38" role="doc-backlink"><span class="sectnum">8.4 </span>Font Alias</a></h3>
 <p>This is the <span class="docutils literal">fontsAlias</span> element. By default, it uses some of the standard PDF
 fonts:</p>
 <pre class="literal-block">fontsAlias:
@@ -1550,7 +1582,7 @@ use aliases.</p>
 <p>More information in the dedicated <a class="reference internal" href="#fonts">Fonts</a> section.</p>
 </section>
 <section id="widows-and-orphans">
-<h3><a class="toc-backref" href="#toc-entry-31" role="doc-backlink"><span class="sectnum">8.5 </span>Widows and Orphans</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-39" role="doc-backlink"><span class="sectnum">8.5 </span>Widows and Orphans</a></h3>
 <dl class="simple">
 <dt><span class="docutils literal">Widow</span></dt>
 <dd><p>A paragraph-ending line that falls at the beginning of the following
@@ -1583,7 +1615,7 @@ minimum number of lines that can be left alone at the beginning of a page
 <p>In future versions this may extend to ordinary paragraphs.</p>
 </section>
 <section id="table-styles">
-<h3><a class="toc-backref" href="#toc-entry-32" role="doc-backlink"><span class="sectnum">8.6 </span>Table Styles</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-40" role="doc-backlink"><span class="sectnum">8.6 </span>Table Styles</a></h3>
 <p>These are a few extra options in styles that are only used when the style is
 applied to a table. This happens in two cases:</p>
 <ol class="arabic simple">
@@ -1667,7 +1699,7 @@ vertical line between the endnote's columns:</p>
 </section>
 </section>
 <section id="syntax-highlighting">
-<h2><a class="toc-backref" href="#toc-entry-33" role="doc-backlink"><span class="sectnum">9 </span>Syntax Highlighting</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-41" role="doc-backlink"><span class="sectnum">9 </span>Syntax Highlighting</a></h2>
 <p>rst2pdf adds a non-standard directive, called <span class="docutils literal"><span class="pre">code-block</span></span>, which produces
 syntax highlighted for many languages using <a class="reference external" href="http://pygments.org/">Pygments</a>.</p>
 <p>For example, if you want to include a Python fragment:</p>
@@ -1803,14 +1835,14 @@ Python.</p>
                             'disabledmodules': string_list,</pre>
 <p>You can find more information about them in the pygments manual.</p>
 <section id="file-inclusion">
-<h3><a class="toc-backref" href="#toc-entry-34" role="doc-backlink"><span class="sectnum">9.1 </span>File inclusion</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-42" role="doc-backlink"><span class="sectnum">9.1 </span>File inclusion</a></h3>
 <p>You can use the <span class="docutils literal"><span class="pre">code-block</span></span> directive with an external file, using the
 <span class="docutils literal">:include:</span> option:</p>
 <pre class="literal-block">.. code-block:: python
-   :include: setup.py</pre>
-<p>This will give a warning if <span class="docutils literal">setup.py</span> doesn't exist or can't be opened.</p>
+   :include: my_script.py</pre>
+<p>This will give a warning if <span class="docutils literal">my_script.py</span> doesn't exist or can't be opened.</p>
 <section id="include-with-boundaries">
-<h4><a class="toc-backref" href="#toc-entry-35" role="doc-backlink"><span class="sectnum">9.1.1 </span>Include with Boundaries</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-43" role="doc-backlink"><span class="sectnum">9.1.1 </span>Include with Boundaries</a></h4>
 <p>You can add selectors to limit the inclusion to a portion of the file.
 The options are:</p>
 <dl class="simple">
@@ -1829,25 +1861,9 @@ The options are:</p>
 <dd><p>will include file up to the first occurrence of string, string <strong>included</strong></p>
 </dd>
 </dl>
-<p>Let's display a class from rst2pdf:</p>
-<pre class="literal-block">.. code-block:: python
-   :include: assets/flowables.py
-   :start-at: class Separation(Flowable):
-   :end-before: class Reference(Flowable):</pre>
-<p>This command gives</p>
-<pre class="code python literal-block"><code><span class="pygments-k">class</span> <span class="pygments-nc">Separation</span><span class="pygments-p">(</span><span class="pygments-n">Flowable</span><span class="pygments-p">):</span><span class="pygments-w">
-    </span><span class="pygments-sd">&quot;&quot;&quot;A simple &lt;hr&gt;-like flowable&quot;&quot;&quot;</span><span class="pygments-w">
-
-</span>    <span class="pygments-k">def</span> <span class="pygments-nf">wrap</span><span class="pygments-p">(</span><span class="pygments-bp">self</span><span class="pygments-p">,</span> <span class="pygments-n">w</span><span class="pygments-p">,</span> <span class="pygments-n">h</span><span class="pygments-p">):</span><span class="pygments-w">
-</span>        <span class="pygments-bp">self</span><span class="pygments-o">.</span><span class="pygments-n">w</span> <span class="pygments-o">=</span> <span class="pygments-n">w</span><span class="pygments-w">
-</span>        <span class="pygments-k">return</span> <span class="pygments-n">w</span><span class="pygments-p">,</span> <span class="pygments-mi">1</span> <span class="pygments-o">*</span> <span class="pygments-n">cm</span><span class="pygments-w">
-
-</span>    <span class="pygments-k">def</span> <span class="pygments-nf">draw</span><span class="pygments-p">(</span><span class="pygments-bp">self</span><span class="pygments-p">):</span><span class="pygments-w">
-</span>        <span class="pygments-bp">self</span><span class="pygments-o">.</span><span class="pygments-n">canv</span><span class="pygments-o">.</span><span class="pygments-n">line</span><span class="pygments-p">(</span><span class="pygments-mi">0</span><span class="pygments-p">,</span> <span class="pygments-mf">0.5</span> <span class="pygments-o">*</span> <span class="pygments-n">cm</span><span class="pygments-p">,</span> <span class="pygments-bp">self</span><span class="pygments-o">.</span><span class="pygments-n">w</span><span class="pygments-p">,</span> <span class="pygments-mf">0.5</span> <span class="pygments-o">*</span> <span class="pygments-n">cm</span><span class="pygments-p">)</span><span class="pygments-w">
-</span></code></pre>
 </section>
 <section id="options">
-<h4><a class="toc-backref" href="#toc-entry-36" role="doc-backlink"><span class="sectnum">9.1.2 </span>Options</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-44" role="doc-backlink"><span class="sectnum">9.1.2 </span>Options</a></h4>
 <dl class="simple">
 <dt><span class="docutils literal">linenos</span></dt>
 <dd><p>Display line numbers along the code</p>
@@ -1862,10 +1878,10 @@ instead of 1.</p>
 </section>
 </section>
 <section id="fonts">
-<h2><a class="toc-backref" href="#toc-entry-37" role="doc-backlink"><span class="sectnum">10 </span>Fonts</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-45" role="doc-backlink"><span class="sectnum">10 </span>Fonts</a></h2>
 <p>Working with fonts on many different platforms is a challenge. Here you will find the best information we have, but questions and updates are always welcome.</p>
 <section id="standard-pdf-fonts">
-<h3><a class="toc-backref" href="#toc-entry-38" role="doc-backlink"><span class="sectnum">10.1 </span>Standard PDF Fonts</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-46" role="doc-backlink"><span class="sectnum">10.1 </span>Standard PDF Fonts</a></h3>
 <p>The standard PDF fonts are always available, here is the list:</p>
 <ul class="simple">
 <li><p><span class="docutils literal">Times_Roman</span></p></li>
@@ -1885,19 +1901,19 @@ instead of 1.</p>
 </ul>
 </section>
 <section id="font-embedding">
-<h3><a class="toc-backref" href="#toc-entry-39" role="doc-backlink"><span class="sectnum">10.2 </span>Font Embedding</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-47" role="doc-backlink"><span class="sectnum">10.2 </span>Font Embedding</a></h3>
 <p>There are thousands of excellent free True Type and Type 1 fonts available on
 the web, and you can use many of them in your documents by declaring them in
 your stylesheet.</p>
 <section id="the-easy-way">
-<h4><a class="toc-backref" href="#toc-entry-40" role="doc-backlink"><span class="sectnum">10.2.1 </span>The Easy Way</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-48" role="doc-backlink"><span class="sectnum">10.2.1 </span>The Easy Way</a></h4>
 <p>Just use the font name in your style. For example, you can define this:</p>
 <pre class="literal-block">normal:
   fontName: fonty</pre>
 <p>And then it <em>may</em> work.</p>
 <p>What would need to happen for this to work?</p>
 <section id="fonty-is-a-true-type-font">
-<h5><a class="toc-backref" href="#toc-entry-41" role="doc-backlink"><span class="sectnum">10.2.1.1 </span>Fonty is a True Type font:</a></h5>
+<h5><a class="toc-backref" href="#toc-entry-49" role="doc-backlink"><span class="sectnum">10.2.1.1 </span>Fonty is a True Type font:</a></h5>
 <ol class="arabic">
 <li><p>You need to have it installed in your system, and have the fc-match
 utility available (it's part of <a class="reference external" href="http://www.freedesktop.org/fontconfig/">fontconfig</a>). You can test if it is
@@ -1918,7 +1934,7 @@ its variants by the aliases <span class="docutils literal"><span class="pre">Nam
 <span class="docutils literal"><span class="pre">Name-BoldOblique</span></span>.</p>
 </section>
 <section id="fonty-is-a-type-1-font">
-<h5><a class="toc-backref" href="#toc-entry-42" role="doc-backlink"><span class="sectnum">10.2.1.2 </span>Fonty is a Type 1 font:</a></h5>
+<h5><a class="toc-backref" href="#toc-entry-50" role="doc-backlink"><span class="sectnum">10.2.1.2 </span>Fonty is a Type 1 font:</a></h5>
 <p>You need it installed, and the folders where its font metric (<span class="docutils literal">.afm</span>) and
 binary (<span class="docutils literal">.pfb</span>) files are located need to be in your font fath.</p>
 <p>For example, the &quot;URW Palladio L&quot; font that came with my installation of TeX
@@ -1949,7 +1965,7 @@ its variants by the aliases Name-Oblique, Name-Bold, Name-BoldOblique.</p>
 </section>
 </section>
 <section id="the-harder-way-true-type">
-<h4><a class="toc-backref" href="#toc-entry-43" role="doc-backlink"><span class="sectnum">10.2.2 </span>The Harder Way (True Type)</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-51" role="doc-backlink"><span class="sectnum">10.2.2 </span>The Harder Way (True Type)</a></h4>
 <p>The stylesheet has an element is <span class="docutils literal">embeddedFonts</span> that handles embedding True
 Type fonts in your PDF. Usually, it's empty, because with the default styles you
 are not using any font beyond the standard PDF fonts:</p>
@@ -1998,9 +2014,9 @@ current folder. You can make it search another folder by passing the
 </section>
 </section>
 <section id="raw-directive">
-<h2><a class="toc-backref" href="#toc-entry-44" role="doc-backlink"><span class="sectnum">11 </span>Raw Directive</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-52" role="doc-backlink"><span class="sectnum">11 </span>Raw Directive</a></h2>
 <section id="raw-pdf">
-<h3><a class="toc-backref" href="#toc-entry-45" role="doc-backlink"><span class="sectnum">11.1 </span>Raw PDF</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-53" role="doc-backlink"><span class="sectnum">11.1 </span>Raw PDF</a></h3>
 <p>rst2pdf has a very limited mechanism to pass commands to reportlab, the PDF
 generation library.  You can use the raw directive to insert pagebreaks and
 spacers (other reportlab flowables may be added if there's interest), and set
@@ -2024,7 +2040,7 @@ And another paragraph.</pre>
 is the same thing in all cases.</p>
 </section>
 <section id="page-counters">
-<h3><a class="toc-backref" href="#toc-entry-46" role="doc-backlink"><span class="sectnum">11.2 </span>Page Counters</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-54" role="doc-backlink"><span class="sectnum">11.2 </span>Page Counters</a></h3>
 <p>In some documents, you may not want your page counter to start in the first
 page.</p>
 <p>For example, if the first pages are a coverpage and a table of contents, you
@@ -2062,7 +2078,7 @@ the page counter to that number.</p>
 </aside>
 </section>
 <section id="page-breaks">
-<h3><a class="toc-backref" href="#toc-entry-47" role="doc-backlink"><span class="sectnum">11.3 </span>Page Breaks</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-55" role="doc-backlink"><span class="sectnum">11.3 </span>Page Breaks</a></h3>
 <p>There are three kinds of page breaks:</p>
 <dl class="simple">
 <dt><span class="docutils literal">PageBreak</span></dt>
@@ -2084,7 +2100,7 @@ setting the background image for this page and how to fit it (One of scale, scal
 <pre class="literal-block">PageBreak background=images/background.jpg fit-background-mode=scale</pre>
 </section>
 <section id="frame-breaks">
-<h3><a class="toc-backref" href="#toc-entry-48" role="doc-backlink"><span class="sectnum">11.4 </span>Frame Breaks</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-56" role="doc-backlink"><span class="sectnum">11.4 </span>Frame Breaks</a></h3>
 <p>If you want to jump to the next frame in the page (or the next page if the
 current frame is the last), you can use the <span class="docutils literal">FrameBreak</span> command. It takes an
 optional height in points, and then it only breaks the frame if there is less
@@ -2099,7 +2115,7 @@ This paragraph is so important that I don't want it at the very bottom of
 the page...</pre>
 </section>
 <section id="page-transitions">
-<h3><a class="toc-backref" href="#toc-entry-49" role="doc-backlink"><span class="sectnum">11.5 </span>Page Transitions</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-57" role="doc-backlink"><span class="sectnum">11.5 </span>Page Transitions</a></h3>
 <p>Page transitions are effects used when you change pages in <em>Presentation</em> or
 <em>Full Screen</em> mode (depends on the viewer).  You can use it when creating a
 presentation using PDF files.</p>
@@ -2142,7 +2158,7 @@ next</em> so the natural thing is to use it before a <span class="docutils liter
    PageBreak</pre>
 </section>
 <section id="text-annotations">
-<h3><a class="toc-backref" href="#toc-entry-50" role="doc-backlink"><span class="sectnum">11.6 </span>Text Annotations</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-58" role="doc-backlink"><span class="sectnum">11.6 </span>Text Annotations</a></h3>
 <p>Text annotations are meta notes added to a page.</p>
 <p>The syntax is this:</p>
 <pre class="literal-block">.. raw:: pdf
@@ -2151,14 +2167,14 @@ next</em> so the natural thing is to use it before a <span class="docutils liter
 <p>The optional position is a set of 4 numbers for <span class="docutils literal">x_begin</span>, <span class="docutils literal">y_begin`, ``x_end</span> and <span class="docutils literal">y_end</span></p>
 </section>
 <section id="raw-html">
-<h3><a class="toc-backref" href="#toc-entry-51" role="doc-backlink"><span class="sectnum">11.7 </span>Raw HTML</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-59" role="doc-backlink"><span class="sectnum">11.7 </span>Raw HTML</a></h3>
 <p>If you have a document that contains raw HTML, and have <span class="docutils literal">xhtml2pdf</span> installed,
 <span class="docutils literal">rst2pdf</span> will try to render that HTML inside your document. To enable this,
 use the <span class="docutils literal"><span class="pre">--raw-html</span></span> command line option.</p>
 </section>
 </section>
 <section id="the-counter-role">
-<h2><a class="toc-backref" href="#toc-entry-52" role="doc-backlink"><span class="sectnum">12 </span>The counter role</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-60" role="doc-backlink"><span class="sectnum">12 </span>The counter role</a></h2>
 <aside class="admonition note">
 <p class="admonition-title">Note</p>
 <p>The counter role only works in PDF, if you're reading the HTML version of
@@ -2188,7 +2204,7 @@ print 2: </p>
 <p>So <span class="docutils literal"><span class="pre">#seq1-2</span></span> should link to <a class="reference external" href="#seq1-2">the number 2 above</a></p>
 </section>
 <section id="the-version-revision-roles">
-<h2><a class="toc-backref" href="#toc-entry-53" role="doc-backlink"><span class="sectnum">13 </span>The version, revision roles</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-61" role="doc-backlink"><span class="sectnum">13 </span>The version, revision roles</a></h2>
 <aside class="admonition note">
 <p class="admonition-title">Note</p>
 <p>These are non-standard roles, which means they will only work with rst2pdf
@@ -2205,7 +2221,7 @@ are running rst2pdf in.</p>
 </aside>
 </section>
 <section id="the-oddeven-directive">
-<h2><a class="toc-backref" href="#toc-entry-54" role="doc-backlink"><span class="sectnum">14 </span>The oddeven directive</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-62" role="doc-backlink"><span class="sectnum">14 </span>The oddeven directive</a></h2>
 <p>This is a nonstandard directive, which means it will only work with rst2pdf, and
 not with rst2html or any other docutils tool.</p>
 <p>The contents of oddeven should consist of <strong>exactly</strong> two things (in this case,
@@ -2237,7 +2253,7 @@ file containing this, it will not do what you want.</p></li>
 </ul>
 </section>
 <section id="mathematics">
-<h2><a class="toc-backref" href="#toc-entry-55" role="doc-backlink"><span class="sectnum">15 </span>Mathematics</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-63" role="doc-backlink"><span class="sectnum">15 </span>Mathematics</a></h2>
 <p>If you have <a class="reference external" href="http://matplotlib.sf.net">Matplotlib</a> installed, rst2pdf supports a math role and a math
 directive. You can use them to insert formulae and mathematical notation in your
 documents using a subset of LaTeX syntax, but doesn't require you have LaTeX
@@ -2269,7 +2285,7 @@ chapter in &quot;The Not So Short Introduction to LaTeX 2e&quot; at <a class="re
 display form is similar to the math directive.</p>
 </section>
 <section id="hyphenation">
-<h2><a class="toc-backref" href="#toc-entry-56" role="doc-backlink"><span class="sectnum">16 </span>Hyphenation</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-64" role="doc-backlink"><span class="sectnum">16 </span>Hyphenation</a></h2>
 <p>If you want good looking documents, you want to enable hyphenation.</p>
 <p>To do it, you first need to install the <span class="docutils literal">pyphen</span> python module.</p>
 <p>Then, you need to specify the language in each style that you want hyphenation
@@ -2302,7 +2318,7 @@ en Ramos Mejía; la enciclopedia falazmente se llama *The Anglo-American Cyclopa
 from its parent, you can do so by setting <span class="docutils literal">hyphenationLang</span> to <span class="docutils literal">0</span>.</p>
 </section>
 <section id="smart-quotes">
-<h2><a class="toc-backref" href="#toc-entry-57" role="doc-backlink"><span class="sectnum">17 </span>Smart Quotes</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-65" role="doc-backlink"><span class="sectnum">17 </span>Smart Quotes</a></h2>
 <p>Quoted from the <a class="reference external" href="http://web.chad.org/projects/smartypants.py/">smartypants</a> documentation:</p>
 <blockquote>
 <p>This feature can perform the following transformations:</p>
@@ -2345,7 +2361,7 @@ for en-dashes.</p>
 regular paragraphs, titles, headers, footers and block quotes.</p>
 </section>
 <section id="sphinx">
-<h2><a class="toc-backref" href="#toc-entry-58" role="doc-backlink"><span class="sectnum">18 </span>Sphinx</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-66" role="doc-backlink"><span class="sectnum">18 </span>Sphinx</a></h2>
 <p><a class="reference external" href="http://sphinx.pocoo.org">Sphinx</a> is a very popular tool. This is the description from its website:</p>
 <blockquote>
 <p>Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -2491,235 +2507,29 @@ pdf_smartquotes = 0</pre>
 did it before.</p>
 </section>
 <section id="extensions">
-<h2><a class="toc-backref" href="#toc-entry-59" role="doc-backlink"><span class="sectnum">19 </span>Extensions</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-67" role="doc-backlink"><span class="sectnum">19 </span>Extensions</a></h2>
 <p>rst2pdf can get new features from <em>extensions</em>. Extensions are python modules
 that can be enabled with the <span class="docutils literal"><span class="pre">-e</span></span> option.</p>
-<p>Several are included with rst2pdf.</p>
-<section id="preprocess-e-preprocess">
-<h3><a class="toc-backref" href="#toc-entry-60" role="doc-backlink"><span class="sectnum">19.1 </span>Preprocess (<span class="docutils literal"><span class="pre">-e</span> preprocess</span>)</a></h3>
-<p>preprocess is a rst2pdf extension module (invoked by <span class="docutils literal"><span class="pre">-e</span> preprocess</span>
-on the rst2pdf command line).</p>
-<p>There is a testcase for this file at tests/test_preprocess.txt</p>
-<p>This preprocesses the source text file before handing it to docutils.</p>
-<p>This module serves two purposes:</p>
-<ol class="arabic simple">
-<li><p>It demonstrates the technique and can be a starting point for similar
-user-written processing modules; and</p></li>
-<li><p>It provides a simplified syntax for documents which are targeted only
-at rst2pdf, rather than docutils in general.</p></li>
-</ol>
-<p>The design goal of &quot;base rst2pdf&quot; is to be completely compatible with
-docutils, such that a file which works as a PDF can also work as HTML,
-etc.</p>
-<p>Unfortunately, base docutils is a slow-moving target, and does not
-make this easy.  For example, SVG images do not work properly with
-the HTML backend unless you install a patch, and docutils has no
-concept of page breaks or additional vertical space (other than
-the &lt;hr&gt;).</p>
-<p>So, while it would be nice to have documents that render perfectly
-with any backend, this goal is hard to achieve for some documents,
-and once you are restricted to a particular transformation type,
-then you might as well have a slightly nicer syntax for your source
-document.</p>
-<hr class="docutils" />
-<p>Preprocessor extensions:</p>
-<p>All current extensions except style occupy a single line in the
-source file.</p>
-<p><span class="docutils literal">.. include::</span></p>
-<blockquote>
-<p>Processes the include file as well.  An include file may
-either be a restructured text file, OR may be an RSON or
-JSON stylesheet.  The determination is made by trying to
-parse it as RSON.  If it passes, it is a stylesheet; if not,
-well, we'll let the docutils parser have its way with it.</p>
-</blockquote>
-<p><span class="docutils literal">.. page::</span></p>
-<blockquote>
-<p>Is translated into a raw PageBreak.</p>
-</blockquote>
-<p><span class="docutils literal">.. space::</span></p>
-<blockquote>
-<p>Is translated into a raw Spacer.  If only one number given, is
-used for vertical space.  This is the canonical use case, since
-horizontal space is ignored anyway!</p>
-</blockquote>
-<p><span class="docutils literal">.. style::</span></p>
-<blockquote>
-<p>Allows you to create in-line stylesheets.  As with other
-restructured text components, the stylesheet data must
-be indented.  Stylesheets are in RSON or JSON.</p>
-</blockquote>
-<p><span class="docutils literal">.. widths::</span></p>
-<blockquote>
-<p>creates a new table style (based on table or the first
-non-numeric token) and creates a class using that style
-specifically for the next table in the document. (Creates
-a .. class::, so you must specify .. widths:: immediately
-before the table it applies to.   Allows you to set the
-widths for the table, using percentages.</p>
-</blockquote>
-<p><span class="docutils literal">SingleWordAtLeftColumn</span></p>
-<blockquote>
-<p>If a single word at the left column is surrounded by
-blank lines, the singleword style is automatically applied to
-the word.  This is a workaround for the broken interaction
-between docutils subtitles and bibliographic metadata.  (I
-found that docutils was referencing my subtitles from inside
-the TOC, and that seemed silly.  Perhaps there is a better
-workaround at a lower level in rst2pdf.)</p>
-</blockquote>
-<hr class="docutils" />
-<p>Preprocessor operation:</p>
-<p>The preprocessor generates a file that has the same name as the source
-file, with .build_temp. embedded in the name, and then passes that
-file to the restructured text parser.</p>
-<p>This file is left on the disk after operation, because any error
-messages from docutils will refer to line numbers in it, rather than
-in the original source, so debugging could be difficult if the
-file were automatically removed.</p>
-</section>
-<section id="dotted-toc-e-dotted-toc">
-<h3><a class="toc-backref" href="#toc-entry-61" role="doc-backlink"><span class="sectnum">19.2 </span>Dotted_TOC (<span class="docutils literal"><span class="pre">-e</span> dotted_toc</span>)</a></h3>
-<!-- NOTE:
-
-THIS IS A HUGE HACK HACK HACK -->
-<p>All I did was take the wrap() method from the stock reportlab TOC generator,
-and make the minimal changes to make it work on MY documents in rst2pdf.</p>
-<p><strong>History:</strong></p>
-<p>The reportlab TOC generator adds nice dots between the text and the page number.
-The rst2pdf one does not.</p>
-<p>A closer examination reveals that the rst2pdf one probably deliberately stripped
-this code, because the reportlab implementation only allowed a single TOC, and
-this is unacceptable for at least some rst2pdf users.</p>
-<p>There are other differences in the rst2pdf one I don't understand.  This module
-is a hack to add back dots between the lines. Maybe at some point we can figure
-out if this is right, or how to support dots in the TOC in the main code.</p>
-<p>Mind you, the original RL implementation is a complete hack in any case:</p>
+<p>Several are included with rst2pdf, and you can also develop extensions yourself.
+Find the included <a class="reference external" href="https://github.com/rst2pdf/rst2pdf/tree/main/rst2pdf/extensions">extensions</a> by inspecting the codebase, each file includes some
+additional information about the extension.</p>
+<p>Extensions include with rst2pdf:</p>
 <ul class="simple">
-<li><p>It uses a callback to a nested function which doesn't even bother to
-assume the original enclosing scope is available at callback time.
-This leads it to do crazy things like eval()</p></li>
-<li><p>It uses a single name in the canvas for the callback function
-(this is what kills multiple TOC capability) when it would be
-extremely easy to generate a unique name.</p></li>
+<li><p><span class="docutils literal">dotted_toc</span> - a (very) experimental extension to add dots to the table of
+contents list between the titles and the page numbers.</p></li>
+<li><p><span class="docutils literal">fancy_titles</span> - an experimental extension to render headings with an SVG template.</p></li>
+<li><p><span class="docutils literal">plantuml_r2p</span> - basic PlantUML support.</p></li>
+<li><p><span class="docutils literal">preprocess</span> - preprocessing tool to make source file changes before
+handing it to docutils, can help keep compatibility between different output
+destinations.</p></li>
 </ul>
-</section>
 </section>
 <section id="developers">
-<h2><a class="toc-backref" href="#toc-entry-62" role="doc-backlink"><span class="sectnum">20 </span>Developers</a></h2>
-<section id="guidelines">
-<h3><a class="toc-backref" href="#toc-entry-63" role="doc-backlink"><span class="sectnum">20.1 </span>Guidelines</a></h3>
-<p>If you want to do something inside rst2pdf, you are welcome! The process looks something like this:</p>
-<ul>
-<li><p>Create an Issue for the task at <a class="reference external" href="https://github.com/rst2pdf/rst2pdf/issues">https://github.com/rst2pdf/rst2pdf/issues</a></p></li>
-<li><p>If you intend to fix a bug:</p>
-<ul>
-<li><p>Create a <strong>minimal</strong> test case that shows the bug.</p></li>
-<li><p>Put it inside <span class="docutils literal">tests/input</span> like the others:</p></li>
-<li><p>Fix the bug</p>
-<p>During this process, you can run the individual test case to quickly
-iterate. For example:</p>
-<pre class="literal-block">pytest tests/input/test_summary_of_test.txt</pre>
-<p>You may also wish to check the logs and output:</p>
-<pre class="literal-block">less tests/output/test_summary_of_test.log
-xdg-open tests/output/test_summary_of_test.pdf  # or 'open' on macOS</pre>
-</li>
-<li><p>Once resolved, copy the generated output PDF, if any, to
-<span class="docutils literal">tests/reference</span> and commit this along with the files in
-<span class="docutils literal">tests/input</span>.</p></li>
-<li><p>Submit a pull request.</p></li>
-</ul>
-</li>
-<li><p>If you added a command line option, document it in <span class="docutils literal">doc/rst2pdf.txt</span>.  That
-will make it appear in the manual and in the man page.</p></li>
-<li><p>If you implemented a new feature, please document it in <span class="docutils literal">manual.rst</span> (or in
-a separate file and add an include in <span class="docutils literal">manual.rst</span>)</p></li>
-<li><p>If you implement an extension, make the docstring valid restructured text and
-link it to the manual like the others.</p></li>
-</ul>
-</section>
-</section>
-<section id="initial-checkout">
-<h2><a class="toc-backref" href="#toc-entry-64" role="doc-backlink"><span class="sectnum">21 </span>Initial checkout</a></h2>
-<p>Clone the repo from <a class="reference external" href="https://github.com/rst2pdf/rst2pdf">https://github.com/rst2pdf/rst2pdf</a>, then install and
-activate a venv:</p>
-<pre class="literal-block">git clone https://github.com/rst2pdf/rst2pdf
-cd rst2pdf
-python3 -m venv .venv
-. .venv/bin/activate</pre>
-<p>Ensure that setuptools and pip are up to date:</p>
-<pre class="literal-block">pip install --upgrade setuptools pip</pre>
-<p>Now you can install rst2pdf from this source code:</p>
-<pre class="literal-block">pip install  -c requirements.txt -e .[aafiguresupport,mathsupport,rawhtmlsupport,sphinx,svgsupport,tests]</pre>
-<p>Note, that on Apple Silicon Macs, you may need this to get tests passing:</p>
-<pre class="literal-block">pip install reportlab==3.6.12 --force-reinstall --no-cache-dir --global-option=build_ext</pre>
-<p>(Look in <span class="docutils literal">requirements.txt</span> for the version of reportlab to use.)</p>
-<p>You can now work on rst2pdf development. Once complete, you can deactivate the
-venv with <span class="docutils literal">deactivate</span>.</p>
-<section id="git-config">
-<h3><a class="toc-backref" href="#toc-entry-65" role="doc-backlink"><span class="sectnum">21.1 </span>Git config</a></h3>
-<p>After the mass-reformatting in PR 877, it is helpful to ignore the relevant
-commits that simply reformatted the code when using git blame.</p>
-<p>The <span class="docutils literal"><span class="pre">..git-blame-ignore-revs</span></span> file contains the list of commits to ignore
-and you can use this git config line to make <span class="docutils literal">git blame</span> work more usefully:</p>
-<pre class="literal-block">git config blame.ignoreRevsFile .git-blame-ignore-revs</pre>
-</section>
-<section id="pre-commit">
-<h3><a class="toc-backref" href="#toc-entry-66" role="doc-backlink"><span class="sectnum">21.2 </span>Pre-commit</a></h3>
-<p><em>rst2pdf</em> uses the <a class="reference external" href="https://pre-commit.com/">pre-commit</a> framework to automate various style checkers.
-This must be enabled locally. You can install this using <em>pip</em> or your local
-package manager. For example, to install using <em>pip</em>:</p>
-<pre class="literal-block">pip install pre-commit</pre>
-<p>Once installed, enable it like so:</p>
-<pre class="literal-block">pre-commit install --allow-missing-config</pre>
-<p>If pre-commit locally behaves differently to CI, then run <span class="docutils literal"><span class="pre">pre-commit</span> clean</span> to
-clear your cache before further investigation.</p>
-</section>
-<section id="continuous-integration">
-<h3><a class="toc-backref" href="#toc-entry-67" role="doc-backlink"><span class="sectnum">21.3 </span>Continuous Integration</a></h3>
-<p>There's a GitHub Actions workflow that runs when we open a pull request or
-merge to main, it does some style checks and runs the test suite.</p>
-</section>
-<section id="running-tests">
-<h3><a class="toc-backref" href="#toc-entry-68" role="doc-backlink"><span class="sectnum">21.4 </span>Running tests</a></h3>
-<p>The <em>rst2pdf</em> test suite generates PDFs - stored in <span class="docutils literal">tests/output</span> -
-which are then compared against reference PDFs - stored in
-<span class="docutils literal">tests/reference</span> - using the <a class="reference external" href="https://pymupdf.readthedocs.io/en/latest/">PyMuPDF</a> Python bindings for the
-<a class="reference external" href="https://mupdf.com/">MuPDF</a> library. <em>rst2pdf</em> depends on a number of different tools and
-libraries, such as <a class="reference external" href="https://www.reportlab.com/">ReportLab</a>, and the output of these can vary slightly
-between releases. The <em>PyMuPDF</em> library allows us to compare the structure
-of the PDFs, with a minor amount of fuzzing to allow for minor differences
-caused by these changes in underlying dependencies.</p>
-<p>To run all the tests enable your venv first if it's not enabled and then call <span class="docutils literal">pytest</span>:</p>
-<pre class="literal-block">pytest</pre>
-<p>You can also run tests in parallel using <span class="docutils literal"><span class="pre">pytest-xdist</span></span> by passing the <span class="docutils literal"><span class="pre">-n</span> auto</span> flag.</p>
-<p>Firstly install:</p>
-<pre class="literal-block">pip install pytest-xdist</pre>
-<p>Then run the tests in parallel:</p>
-<pre class="literal-block">pytest -n auto</pre>
-<section id="running-a-single-test">
-<h4><a class="toc-backref" href="#toc-entry-69" role="doc-backlink"><span class="sectnum">21.4.1 </span>Running a single test</a></h4>
-<p>To run one test only, simply pass the file or directory to pytest. For example:</p>
-<pre class="literal-block">pytest tests/input/sphinx-repeat-table-rows</pre>
-<p>This will run one test and show the output.</p>
-</section>
-<section id="skipping-tests">
-<h4><a class="toc-backref" href="#toc-entry-70" role="doc-backlink"><span class="sectnum">21.4.2 </span>Skipping tests</a></h4>
-<p>To skip a test, simply create a text file in the <span class="docutils literal">tests/input</span> directory
-called <span class="docutils literal"><span class="pre">[test].ignore</span></span> containing a note on why the test is skipped. This
-will mark the test as skipped when the test suite runs. This could be useful
-for inherited tests that we aren't confident of the correct output for, but
-where we don't want to delete/lose the test entirely.</p>
-<aside class="admonition note">
-<p class="admonition-title">Note</p>
-<p>Some tests require the execution of the <span class="docutils literal">dot</span> command, you should install
-the package graphviz from your packages manager.</p>
-</aside>
-</section>
-</section>
+<h2><a class="toc-backref" href="#toc-entry-68" role="doc-backlink"><span class="sectnum">20 </span>Developers</a></h2>
+<p>To contribute to rst2pdf, visit the <a class="reference external" href="https://github.com/rst2pdf/rst2pdf">project</a> on GitHub to get started.</p>
 </section>
 <section id="licenses">
-<h2><a class="toc-backref" href="#toc-entry-71" role="doc-backlink"><span class="sectnum">22 </span>Licenses</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-69" role="doc-backlink"><span class="sectnum">21 </span>Licenses</a></h2>
 <p>This is the license for rst2pdf:</p>
 <pre class="literal-block">Copyright (c) 2007-2020 Roberto Alsina and the contributors to the rst2pdf project
 

--- a/static/manual.pdf
+++ b/static/manual.pdf
@@ -2,8 +2,8 @@
 %ìåãû ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/F1 2 0 R /F10+0 256 0 R /F2+0 248 0 R /F3 5 0 R /F4 6 0 R /F5 126 0 R 
-  /F6 160 0 R /F7 161 0 R /F8 176 0 R /F9+0 252 0 R
+/F1 2 0 R /F10+0 245 0 R /F2+0 237 0 R /F3 5 0 R /F4 6 0 R /F5 147 0 R 
+  /F6 153 0 R /F7 158 0 R /F8 159 0 R /F9+0 241 0 R
 >>
 endobj
 2 0 obj
@@ -21,7 +21,7 @@ s4IA1!#S.LBk@>F8P(B3#QOi)zzs6K^t7!3!TGlRjF"98E%A,lW0i<(]GFEDI_0/%3a/n&:/@V%0%Df%
 endobj
 4 0 obj
 <<
-/Contents 332 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 319 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.b1bf2fe7e90e108a689158f75eca11cc 3 0 R
 >>
@@ -43,402 +43,402 @@ endobj
 endobj
 7 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 156 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 706.8236 118.4191 717.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 152 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 706.8236 118.4191 717.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 8 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 156 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 707.4611 538.252 717.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 152 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 707.4611 538.252 717.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 9 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 156 0 R /XYZ 57.02362 570.8236 0 ] /Rect [ 77.02362 690.6236 159.2356 700.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 152 0 R /XYZ 57.02362 570.8236 0 ] /Rect [ 77.02362 690.6236 159.2356 700.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 10 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 156 0 R /XYZ 57.02362 570.8236 0 ] /Rect [ 533.526 691.2611 538.252 701.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 152 0 R /XYZ 57.02362 570.8236 0 ] /Rect [ 533.526 691.2611 538.252 701.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 11 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 674.4236 160.4601 684.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 674.4236 160.4601 684.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 12 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 675.0611 538.252 685.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 675.0611 538.252 685.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 13 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 162 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 658.2236 141.5646 668.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 696.0236 0 ] /Rect [ 77.02362 658.2236 157.8161 668.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 14 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 162 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 658.8611 538.252 669.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 696.0236 0 ] /Rect [ 533.526 658.8611 538.252 669.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 15 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 164 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 642.0236 113.7186 652.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 546.0236 0 ] /Rect [ 77.02362 642.0236 179.0746 652.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 16 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 164 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 642.6611 538.252 652.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 546.0236 0 ] /Rect [ 533.526 642.6611 538.252 652.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 17 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 625.8236 98.12962 636.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 432.0236 0 ] /Rect [ 77.02362 625.8236 153.0901 636.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 18 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 626.4611 538.252 636.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 432.0236 0 ] /Rect [ 533.526 626.4611 538.252 636.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 19 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 77.02362 609.6236 116.2426 619.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 264.0236 0 ] /Rect [ 77.02362 609.6236 144.5816 619.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 20 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 528.8 610.2611 538.252 620.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 154 0 R /XYZ 57.02362 264.0236 0 ] /Rect [ 533.526 610.2611 538.252 620.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 21 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 588.8236 0 ] /Rect [ 77.02362 593.4236 186.6396 603.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 155 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 593.4236 168.2031 603.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 22 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 588.8236 0 ] /Rect [ 528.8 594.0611 538.252 604.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 155 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 594.0611 538.252 604.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 23 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 313.8236 0 ] /Rect [ 77.02362 577.2236 138.4446 587.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 155 0 R /XYZ 57.02362 459.0236 0 ] /Rect [ 77.02362 577.2236 181.4291 587.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 24 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 168 0 R /XYZ 57.02362 313.8236 0 ] /Rect [ 528.8 577.8611 538.252 588.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 155 0 R /XYZ 57.02362 459.0236 0 ] /Rect [ 533.526 577.8611 538.252 588.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 25 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 561.0236 170.8556 571.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 561.0236 141.5646 571.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 26 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 561.6611 538.252 571.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 561.6611 538.252 571.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 27 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 642.0236 0 ] /Rect [ 77.02362 544.8236 154.0336 555.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 636.0236 0 ] /Rect [ 77.02362 544.8236 178.1311 555.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 28 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 642.0236 0 ] /Rect [ 528.8 545.4611 538.252 555.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 636.0236 0 ] /Rect [ 533.526 545.4611 538.252 555.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 29 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 152.4236 0 ] /Rect [ 77.02362 528.6236 175.7681 538.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 160 0 R /XYZ 57.02362 447.0236 0 ] /Rect [ 77.02362 528.6236 197.9616 538.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 30 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 173 0 R /XYZ 57.02362 152.4236 0 ] /Rect [ 528.8 529.2611 538.252 539.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 160 0 R /XYZ 57.02362 447.0236 0 ] /Rect [ 533.526 529.2611 538.252 539.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 31 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 179 0 R /XYZ 57.02362 426.8236 0 ] /Rect [ 77.02362 512.4236 133.7271 522.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 161 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 512.4236 113.7186 522.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 32 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 179 0 R /XYZ 57.02362 426.8236 0 ] /Rect [ 528.8 513.0611 538.252 523.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 161 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 533.526 513.0611 538.252 523.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 33 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 496.2236 169.4191 506.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 496.2236 98.12962 506.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 34 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 496.8611 538.252 507.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 496.8611 538.252 507.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 35 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 594.0236 0 ] /Rect [ 77.02362 480.0236 163.9531 490.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 77.02362 480.0236 116.2426 490.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 36 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 594.0236 0 ] /Rect [ 528.8 480.6611 538.252 490.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 528.8 480.6611 538.252 490.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 37 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 307.6236 0 ] /Rect [ 77.02362 463.8236 175.7766 474.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 588.8236 0 ] /Rect [ 77.02362 463.8236 186.6396 474.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 38 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 307.6236 0 ] /Rect [ 528.8 464.4611 538.252 474.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 588.8236 0 ] /Rect [ 528.8 464.4611 538.252 474.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 39 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 558.8236 0 ] /Rect [ 77.02362 447.6236 164.9051 457.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 313.8236 0 ] /Rect [ 77.02362 447.6236 138.4446 457.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 40 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 558.8236 0 ] /Rect [ 528.8 448.2611 538.252 458.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 165 0 R /XYZ 57.02362 313.8236 0 ] /Rect [ 528.8 448.2611 538.252 458.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 41 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 445.6236 0 ] /Rect [ 77.02362 431.4236 202.2116 441.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 431.4236 170.8556 441.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 42 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 445.6236 0 ] /Rect [ 528.8 432.0611 538.252 442.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 432.0611 538.252 442.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 43 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 272.8387 0 ] /Rect [ 77.02362 415.2236 245.2131 425.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 642.0236 0 ] /Rect [ 77.02362 415.2236 154.0336 425.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 44 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 272.8387 0 ] /Rect [ 528.8 415.8611 538.252 426.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 642.0236 0 ] /Rect [ 528.8 415.8611 538.252 426.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 45 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 125.6387 0 ] /Rect [ 97.02362 399.0236 224.5831 409.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 152.4236 0 ] /Rect [ 77.02362 399.0236 175.7681 409.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 46 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 125.6387 0 ] /Rect [ 528.8 399.6611 538.252 409.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 170 0 R /XYZ 57.02362 152.4236 0 ] /Rect [ 528.8 399.6611 538.252 409.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 47 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 183 0 R /XYZ 57.02362 465.0236 0 ] /Rect [ 97.02362 382.8236 242.0676 393.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 175 0 R /XYZ 57.02362 426.8236 0 ] /Rect [ 77.02362 382.8236 133.7271 393.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 48 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 183 0 R /XYZ 57.02362 465.0236 0 ] /Rect [ 528.8 383.4611 538.252 393.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 175 0 R /XYZ 57.02362 426.8236 0 ] /Rect [ 528.8 383.4611 538.252 393.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 49 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 366.6236 152.9206 376.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 366.6236 169.4191 376.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 50 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 367.2611 538.252 377.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 367.2611 538.252 377.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 51 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 536.8236 0 ] /Rect [ 77.02362 350.4236 152.1381 360.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 594.0236 0 ] /Rect [ 77.02362 350.4236 163.9531 360.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 52 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 536.8236 0 ] /Rect [ 528.8 351.0611 538.252 361.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 594.0236 0 ] /Rect [ 528.8 351.0611 538.252 361.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 53 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 334.2236 152.6141 344.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 307.6236 0 ] /Rect [ 77.02362 334.2236 175.7766 344.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 54 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 334.8611 538.252 345.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 176 0 R /XYZ 57.02362 307.6236 0 ] /Rect [ 528.8 334.8611 538.252 345.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 55 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 363.4236 0 ] /Rect [ 97.02362 318.0236 168.8401 328.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 558.8236 0 ] /Rect [ 77.02362 318.0236 164.9051 328.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 56 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 363.4236 0 ] /Rect [ 528.8 318.6611 538.252 328.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 558.8236 0 ] /Rect [ 528.8 318.6611 538.252 328.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 57 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 246.4236 0 ] /Rect [ 97.02362 301.8236 140.4926 312.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 445.6236 0 ] /Rect [ 77.02362 301.8236 202.2116 312.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 58 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 246.4236 0 ] /Rect [ 528.8 302.4611 538.252 312.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 445.6236 0 ] /Rect [ 528.8 302.4611 538.252 312.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 59 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 462.6236 0 ] /Rect [ 77.02362 285.6236 143.6551 295.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 272.8387 0 ] /Rect [ 77.02362 285.6236 245.2131 295.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 60 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 462.6236 0 ] /Rect [ 528.8 286.2611 538.252 296.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 272.8387 0 ] /Rect [ 528.8 286.2611 538.252 296.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 61 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 402.6236 0 ] /Rect [ 97.02362 269.4236 167.4376 279.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 125.6387 0 ] /Rect [ 97.02362 269.4236 224.5831 279.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 62 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 402.6236 0 ] /Rect [ 528.8 270.0611 538.252 280.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 178 0 R /XYZ 57.02362 125.6387 0 ] /Rect [ 528.8 270.0611 538.252 280.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 63 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 193 0 R /XYZ 57.02362 677.8236 0 ] /Rect [ 97.02362 253.2236 184.9051 263.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 179 0 R /XYZ 57.02362 465.0236 0 ] /Rect [ 97.02362 253.2236 242.0676 263.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 64 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 193 0 R /XYZ 57.02362 677.8236 0 ] /Rect [ 528.8 253.8611 538.252 264.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 179 0 R /XYZ 57.02362 465.0236 0 ] /Rect [ 528.8 253.8611 538.252 264.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 65 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 473.8236 0 ] /Rect [ 77.02362 237.0236 133.7186 247.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 237.0236 152.9206 247.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 66 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 473.8236 0 ] /Rect [ 528.8 237.6611 538.252 247.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 237.6611 538.252 247.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 67 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 270.6236 0 ] /Rect [ 77.02362 220.8236 177.1791 231.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 536.8236 0 ] /Rect [ 77.02362 220.8236 152.1381 231.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 68 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 270.6236 0 ] /Rect [ 528.8 221.4611 538.252 231.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 536.8236 0 ] /Rect [ 528.8 221.4611 538.252 231.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 69 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 581.8236 0 ] /Rect [ 77.02362 204.6236 142.6946 214.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 183 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 204.6236 152.6141 214.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 70 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 581.8236 0 ] /Rect [ 528.8 205.2611 538.252 215.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 183 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 205.2611 538.252 215.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 71 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 188.4236 148.6536 198.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 363.4236 0 ] /Rect [ 97.02362 188.4236 168.8401 198.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 72 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 189.0611 538.252 199.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 363.4236 0 ] /Rect [ 528.8 189.0611 538.252 199.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 73 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 172.2236 145.0491 182.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 246.4236 0 ] /Rect [ 97.02362 172.2236 140.4926 182.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 74 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 172.8611 538.252 183.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 246.4236 0 ] /Rect [ 528.8 172.8611 538.252 183.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 75 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 633.8236 0 ] /Rect [ 97.02362 156.0236 213.2526 166.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 462.6236 0 ] /Rect [ 77.02362 156.0236 143.6551 166.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 76 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 633.8236 0 ] /Rect [ 528.8 156.6611 538.252 166.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 462.6236 0 ] /Rect [ 528.8 156.6611 538.252 166.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 77 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 228.4236 0 ] /Rect [ 97.02362 139.8236 152.3076 150.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 402.6236 0 ] /Rect [ 97.02362 139.8236 167.4376 150.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 78 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 228.4236 0 ] /Rect [ 528.8 140.4611 538.252 150.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 402.6236 0 ] /Rect [ 528.8 140.4611 538.252 150.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 79 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 123.6236 96.70162 133.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 189 0 R /XYZ 57.02362 677.8236 0 ] /Rect [ 97.02362 123.6236 184.9051 133.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 80 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 124.2611 538.252 134.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 189 0 R /XYZ 57.02362 677.8236 0 ] /Rect [ 528.8 124.2611 538.252 134.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 81 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 684.0236 0 ] /Rect [ 77.02362 107.4236 178.1311 117.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 473.8236 0 ] /Rect [ 77.02362 107.4236 133.7186 117.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 82 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 684.0236 0 ] /Rect [ 528.8 108.0611 538.252 118.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 473.8236 0 ] /Rect [ 528.8 108.0611 538.252 118.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 83 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 384.0236 0 ] /Rect [ 77.02362 91.22362 163.0181 101.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 270.6236 0 ] /Rect [ 77.02362 91.22362 177.1791 101.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 84 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 384.0236 0 ] /Rect [ 528.8 91.86112 538.252 102.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 270.6236 0 ] /Rect [ 528.8 91.86112 538.252 102.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 85 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 324.0236 0 ] /Rect [ 97.02362 75.02362 183.0096 85.22362 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 581.8236 0 ] /Rect [ 77.02362 75.02362 142.6946 85.22362 ] /Subtype /Link /Type /Annot
 >>
 endobj
 86 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 324.0236 0 ] /Rect [ 528.8 75.66112 538.252 85.86112 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 581.8236 0 ] /Rect [ 528.8 75.66112 538.252 85.86112 ] /Subtype /Link /Type /Annot
 >>
 endobj
 87 0 obj
@@ -450,7 +450,7 @@ endobj
   47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 
   57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 
   67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 
-  77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R ] /Contents 333 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+  77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R ] /Contents 320 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -460,328 +460,302 @@ endobj
 endobj
 88 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 195.8236 0 ] /Rect [ 117.0236 733.8236 251.6806 744.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 733.8236 148.6536 744.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 89 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 195.8236 0 ] /Rect [ 528.8 734.4611 538.252 744.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 734.4611 538.252 744.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 90 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 609.8236 0 ] /Rect [ 117.0236 717.6236 238.9306 727.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 717.6236 145.0491 727.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 91 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 609.8236 0 ] /Rect [ 528.8 718.2611 538.252 728.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 718.2611 538.252 728.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 92 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 139.0236 0 ] /Rect [ 97.02362 701.4236 236.8486 711.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 633.8236 0 ] /Rect [ 97.02362 701.4236 213.2526 711.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 93 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 139.0236 0 ] /Rect [ 528.8 702.0611 538.252 712.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 633.8236 0 ] /Rect [ 528.8 702.0611 538.252 712.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 94 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 685.2236 129.3076 695.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 464.8236 0 ] /Rect [ 97.02362 685.2236 152.3076 695.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 95 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 685.8611 538.252 696.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 464.8236 0 ] /Rect [ 528.8 685.8611 538.252 696.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 96 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 77.02362 669.0236 137.0166 679.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 669.0236 96.70162 679.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 97 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 528.8 669.6611 538.252 679.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 669.6611 538.252 679.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 98 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 402.8236 0 ] /Rect [ 77.02362 652.8236 157.3486 663.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 684.0236 0 ] /Rect [ 77.02362 652.8236 178.1311 663.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 99 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 402.8236 0 ] /Rect [ 528.8 653.4611 538.252 663.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 684.0236 0 ] /Rect [ 528.8 653.4611 538.252 663.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 100 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 577.0236 0 ] /Rect [ 77.02362 636.6236 149.3161 646.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 384.0236 0 ] /Rect [ 77.02362 636.6236 163.0181 646.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 101 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 577.0236 0 ] /Rect [ 528.8 637.2611 538.252 647.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 384.0236 0 ] /Rect [ 528.8 637.2611 538.252 647.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 102 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 254.4236 0 ] /Rect [ 77.02362 620.4236 154.0251 630.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 324.0236 0 ] /Rect [ 97.02362 620.4236 183.0096 630.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 103 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 254.4236 0 ] /Rect [ 528.8 621.0611 538.252 631.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 324.0236 0 ] /Rect [ 528.8 621.0611 538.252 631.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 104 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 604.2236 164.4291 614.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 195.8236 0 ] /Rect [ 117.0236 604.2236 251.6806 614.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 105 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 604.8611 538.252 615.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 195.8236 0 ] /Rect [ 528.8 604.8611 538.252 615.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 106 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 178.4236 0 ] /Rect [ 77.02362 588.0236 164.4376 598.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 609.8236 0 ] /Rect [ 117.0236 588.0236 238.9306 598.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 107 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 178.4236 0 ] /Rect [ 528.8 588.6611 538.252 598.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 609.8236 0 ] /Rect [ 528.8 588.6611 538.252 598.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 108 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 723.0236 0 ] /Rect [ 77.02362 571.8236 143.1536 582.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 139.0236 0 ] /Rect [ 97.02362 571.8236 236.8486 582.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 109 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 723.0236 0 ] /Rect [ 528.8 572.4611 538.252 582.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 139.0236 0 ] /Rect [ 528.8 572.4611 538.252 582.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 110 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 216 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 555.6236 140.1621 565.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 555.6236 129.3076 565.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 111 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 216 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 556.2611 538.252 566.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 556.2611 538.252 566.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 112 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 539.4236 181.2766 549.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 77.02362 539.4236 137.0166 549.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 113 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 540.0611 538.252 550.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 528.8 540.0611 538.252 550.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 114 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 523.2236 163.3161 533.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 402.8236 0 ] /Rect [ 77.02362 523.2236 157.3486 533.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 115 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 523.8611 538.252 534.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 402.8236 0 ] /Rect [ 528.8 523.8611 538.252 534.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 116 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 223 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 507.0236 125.0491 517.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 577.0236 0 ] /Rect [ 77.02362 507.0236 149.3161 517.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 117 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 223 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 507.6611 538.252 517.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 577.0236 0 ] /Rect [ 528.8 507.6611 538.252 517.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 118 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 490.8236 125.0406 501.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 254.4236 0 ] /Rect [ 77.02362 490.8236 154.0251 501.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 119 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 491.4611 538.252 501.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 254.4236 0 ] /Rect [ 528.8 491.4611 538.252 501.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 120 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 226 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 474.6236 129.2991 484.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 474.6236 164.4291 484.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 121 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 226 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 475.2611 538.252 485.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 475.2611 538.252 485.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 122 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 458.4236 101.9036 468.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 178.4236 0 ] /Rect [ 77.02362 458.4236 164.4376 468.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 123 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 459.0611 538.252 469.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 178.4236 0 ] /Rect [ 528.8 459.0611 538.252 469.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 124 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 442.2236 118.9121 452.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 723.0236 0 ] /Rect [ 77.02362 442.2236 143.1536 452.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 125 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 442.8611 538.252 453.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 723.0236 0 ] /Rect [ 528.8 442.8611 538.252 453.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 126 0 obj
 <<
-/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 426.0236 140.1621 436.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 127 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 666.0236 0 ] /Rect [ 77.02362 426.0236 217.9621 436.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 426.6611 538.252 436.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 128 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 666.0236 0 ] /Rect [ 528.8 426.6611 538.252 436.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 409.8236 181.2766 420.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 129 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 232 0 R /XYZ 57.02362 568.6772 0 ] /Rect [ 77.02362 409.8236 222.6881 420.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 410.4611 538.252 420.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 130 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 232 0 R /XYZ 57.02362 568.6772 0 ] /Rect [ 528.8 410.4611 538.252 420.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 393.6236 163.3161 403.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 131 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 234 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 393.6236 119.3881 403.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 394.2611 538.252 404.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 132 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 234 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 394.2611 538.252 404.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 219 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 377.4236 125.0491 387.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 133 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 234 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 77.02362 377.4236 140.8076 387.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 219 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 378.0611 538.252 388.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 134 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 234 0 R /XYZ 57.02362 714.0236 0 ] /Rect [ 528.8 378.0611 538.252 388.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 361.2236 125.0406 371.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 135 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 361.2236 135.4446 371.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 361.8611 538.252 372.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 136 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 361.8611 538.252 372.0611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 222 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 345.0236 129.2991 355.2236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 137 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 438.362 0 ] /Rect [ 77.02362 345.0236 136.5576 355.2236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 222 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 345.6611 538.252 355.8611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 138 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 438.362 0 ] /Rect [ 528.8 345.6611 538.252 355.8611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 328.8236 101.9036 339.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 139 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 315.162 0 ] /Rect [ 77.02362 328.8236 144.0971 339.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 329.4611 538.252 339.6611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 140 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 315.162 0 ] /Rect [ 528.8 329.4611 538.252 339.6611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 312.6236 118.9121 322.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 141 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 136.762 0 ] /Rect [ 77.02362 312.6236 186.1721 322.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 313.2611 538.252 323.4611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 142 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 237 0 R /XYZ 57.02362 136.762 0 ] /Rect [ 528.8 313.2611 538.252 323.4611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 230 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 296.4236 119.3881 306.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 143 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 77.02362 296.4236 152.6226 306.6236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 230 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 297.0611 538.252 307.2611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 144 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 297.0611 538.252 307.2611 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 280.2236 109.9446 290.4236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 145 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 475.4236 0 ] /Rect [ 97.02362 280.2236 207.1156 290.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 280.8611 538.252 291.0611 ] /Subtype /Link /Type /Annot
 >>
 endobj
 146 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 475.4236 0 ] /Rect [ 528.8 280.8611 538.252 291.0611 ] /Subtype /Link /Type /Annot
->>
-endobj
-147 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 377.2236 0 ] /Rect [ 97.02362 264.0236 180.6551 274.2236 ] /Subtype /Link /Type /Annot
->>
-endobj
-148 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 241 0 R /XYZ 57.02362 377.2236 0 ] /Rect [ 528.8 264.6611 538.252 274.8611 ] /Subtype /Link /Type /Annot
->>
-endobj
-149 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 242 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 57.02362 247.8236 109.9446 258.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-150 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 242 0 R /XYZ 57.02362 747.0236 0 ] /Rect [ 528.8 248.4611 538.252 258.6611 ] /Subtype /Link /Type /Annot
->>
-endobj
-151 0 obj
-<<
 /Annots [ 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R 97 0 R 
   98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 106 0 R 107 0 R 
   108 0 R 109 0 R 110 0 R 111 0 R 112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R 
-  118 0 R 119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 125 0 R 127 0 R 128 0 R 
-  129 0 R 130 0 R 131 0 R 132 0 R 133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 138 0 R 
-  139 0 R 140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R 146 0 R 147 0 R 148 0 R 
-  149 0 R 150 0 R ] /Contents 334 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+  118 0 R 119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 125 0 R 126 0 R 127 0 R 
+  128 0 R 129 0 R 130 0 R 131 0 R 132 0 R 133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 
+  138 0 R 139 0 R 140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R ] /Contents 321 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -789,82 +763,82 @@ endobj
 >> /Type /Page
 >>
 endobj
-152 0 obj
+147 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+148 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://docutils.sourceforge.io/docs/user/rst/quickstart.html)
 >> /Border [ 0 0 0 ] /Rect [ 200.0536 501.8236 457.3736 513.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-153 0 obj
+149 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://docutils.sourceforge.io/docs/user/rst/quickref.html)
 >> /Border [ 0 0 0 ] /Rect [ 192.2836 483.8236 441.8236 495.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-154 0 obj
+150 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)
 >> /Border [ 0 0 0 ] /Rect [ 223.4136 465.8236 499.6336 477.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-155 0 obj
+151 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://docutils.sourceforge.io/docs/ref/rst/directives.html)
 >> /Border [ 0 0 0 ] /Rect [ 210.6136 447.8236 459.5936 459.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-156 0 obj
+152 0 obj
 <<
-/Annots [ 152 0 R 153 0 R 154 0 R 155 0 R ] /Contents 335 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 148 0 R 149 0 R 150 0 R 151 0 R ] /Contents 322 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
 
 >> /Type /Page
+>>
+endobj
+153 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+154 0 obj
+<<
+/Contents 323 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+155 0 obj
+<<
+/Contents 324 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+156 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 233 0 R /XYZ 63.02362 720.6772 0 ] /Rect [ 507.7036 653.4236 512.1516 663.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 157 0 obj
 <<
-/Contents 336 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-158 0 obj
-<<
-/Contents 337 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-159 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 244 0 R /XYZ 63.02362 720.6772 0 ] /Rect [ 507.7036 683.4236 512.1516 693.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-160 0 obj
-<<
-/BaseFont /Courier-Oblique /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
->>
-endobj
-161 0 obj
-<<
-/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F7 /Subtype /Type1 /Type /Font
->>
-endobj
-162 0 obj
-<<
-/Annots [ 159 0 R ] /Contents 338 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 156 0 R ] /Contents 325 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -872,9 +846,19 @@ endobj
 >> /Type /Page
 >>
 endobj
-163 0 obj
+158 0 obj
 <<
-/Contents 339 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/BaseFont /Courier-Oblique /Encoding /WinAnsiEncoding /Name /F7 /Subtype /Type1 /Type /Font
+>>
+endobj
+159 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F8 /Subtype /Type1 /Type /Font
+>>
+endobj
+160 0 obj
+<<
+/Contents 326 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -882,9 +866,9 @@ endobj
   /Type /Page
 >>
 endobj
-164 0 obj
+161 0 obj
 <<
-/Contents 340 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 327 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -892,15 +876,15 @@ endobj
   /Type /Page
 >>
 endobj
-165 0 obj
+162 0 obj
 <<
-/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 16 /Length 99 /SMask 166 0 R 
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 16 /Length 99 /SMask 163 0 R 
   /Subtype /Image /Type /XObject /Width 16
 >>
 stream
 Gatmt9+h4I#XZ*%V/<(u@uBmr=V8?K0\Z^q/;*/(FTbVb3Ll+WIX_`d$OKqrhCOVS4K[m&h"\hN?W/1;46b`nm1lV<!HV&h2?~>endstream
 endobj
-166 0 obj
+163 0 obj
 <<
 /BitsPerComponent 8 /ColorSpace /DeviceGray /Decode [ 0 1 ] /Filter [ /ASCII85Decode /FlateDecode ] /Height 16 /Length 79 
   /Subtype /Image /Type /XObject /Width 16
@@ -908,18 +892,18 @@ endobj
 stream
 Garo:>7(?q#Qh^>V.UmD[)>FE;]dLV,"$5=!J\H3Ass.*<A8`&l2'%jdYAJYp@aT^*:oS:!EDBnT)~>endstream
 endobj
-167 0 obj
+164 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://pypi.org/project/svglib/)
 >> /Border [ 0 0 0 ] /Rect [ 220.9936 522.8236 246.5536 534.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-168 0 obj
+165 0 obj
 <<
-/Annots [ 167 0 R ] /Contents 341 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 164 0 R ] /Contents 328 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.4afb2edf7d2506d7a99dd1a3ec07592d 165 0 R
+/FormXob.4afb2edf7d2506d7a99dd1a3ec07592d 162 0 R
 >>
 >> /Rotate 0 
   /Trans <<
@@ -927,9 +911,9 @@ endobj
 >> /Type /Page
 >>
 endobj
-169 0 obj
+166 0 obj
 <<
-/Contents 342 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 329 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -937,59 +921,54 @@ endobj
   /Type /Page
 >>
 endobj
+167 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 480.5136 498.0236 536.8271 510.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+168 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 180 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 57.02362 486.0236 108.7136 498.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+169 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 187 0 R /XYZ 57.02362 365.9236 0 ] /Rect [ 106.4936 164.4236 158.1736 176.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
 170 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 480.5136 498.0236 536.8271 510.0236 ] /Subtype /Link /Type /Annot
+/Annots [ 167 0 R 168 0 R 169 0 R ] /Contents 330 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
 >>
 endobj
 171 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 57.02362 486.0236 108.7136 498.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 405.8236 0 ] /Rect [ 309.3636 486.8236 372.7336 498.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 172 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 365.9236 0 ] /Rect [ 106.4936 164.4236 158.1736 176.4236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 189 0 R /XYZ 57.02362 628.8236 0 ] /Rect [ 404.9736 468.8236 480.138 480.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 173 0 obj
 <<
-/Annots [ 170 0 R 171 0 R 172 0 R ] /Contents 343 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 429.4336 456.8236 502.2436 468.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 174 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 405.8236 0 ] /Rect [ 309.3636 486.8236 372.7336 498.8236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 431.9136 438.8236 530.2936 450.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 175 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 193 0 R /XYZ 57.02362 628.8236 0 ] /Rect [ 404.9736 468.8236 480.138 480.8236 ] /Subtype /Link /Type /Annot
->>
-endobj
-176 0 obj
-<<
-/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F8 /Subtype /Type1 /Type /Font
->>
-endobj
-177 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 162 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 429.4336 456.8236 502.2436 468.8236 ] /Subtype /Link /Type /Annot
->>
-endobj
-178 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 431.9136 438.8236 530.2936 450.8236 ] /Subtype /Link /Type /Annot
->>
-endobj
-179 0 obj
-<<
-/Annots [ 174 0 R 175 0 R 177 0 R 178 0 R ] /Contents 344 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 171 0 R 172 0 R 173 0 R 174 0 R ] /Contents 331 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -997,9 +976,44 @@ endobj
 >> /Type /Page
 >>
 endobj
+176 0 obj
+<<
+/Contents 332 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+177 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 97.59362 622.0236 183.1836 634.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+178 0 obj
+<<
+/Annots [ 177 0 R ] /Contents 333 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+179 0 obj
+<<
+/Contents 334 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
 180 0 obj
 <<
-/Contents 345 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 335 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1009,12 +1023,17 @@ endobj
 endobj
 181 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 97.59362 622.0236 183.1836 634.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 476.8236 0 ] /Rect [ 100.0236 428.3736 144.4836 440.3736 ] /Subtype /Link /Type /Annot
 >>
 endobj
 182 0 obj
 <<
-/Annots [ 181 0 R ] /Contents 346 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 100.0236 410.3736 125.0336 422.3736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+183 0 obj
+<<
+/Annots [ 181 0 R 182 0 R ] /Contents 336 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1022,39 +1041,29 @@ endobj
 >> /Type /Page
 >>
 endobj
-183 0 obj
-<<
-/Contents 347 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
 184 0 obj
 <<
-/Contents 348 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 584.8236 0 ] /Rect [ 100.0236 446.3736 155.0436 458.3736 ] /Subtype /Link /Type /Annot
 >>
 endobj
 185 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 476.8236 0 ] /Rect [ 100.0236 428.3736 144.4836 440.3736 ] /Subtype /Link /Type /Annot
+/Annots [ 184 0 R ] /Contents 337 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
 >>
 endobj
 186 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 100.0236 410.3736 125.0336 422.3736 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 273.6236 0 ] /Rect [ 80.02362 556.3736 175.6136 568.3736 ] /Subtype /Link /Type /Annot
 >>
 endobj
 187 0 obj
 <<
-/Annots [ 185 0 R 186 0 R ] /Contents 349 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 186 0 R ] /Contents 338 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1064,27 +1073,32 @@ endobj
 endobj
 188 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 196 0 R /XYZ 57.02362 584.8236 0 ] /Rect [ 100.0236 446.3736 155.0436 458.3736 ] /Subtype /Link /Type /Annot
+/Contents 339 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 189 0 obj
 <<
-/Annots [ 188 0 R ] /Contents 350 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 340 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
+>> /Rotate 0 /Trans <<
 
->> /Type /Page
+>> 
+  /Type /Page
 >>
 endobj
 190 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 273.6236 0 ] /Rect [ 80.02362 556.3736 175.6136 568.3736 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 208.2036 282.6236 233.2136 294.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 191 0 obj
 <<
-/Annots [ 190 0 R ] /Contents 351 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 190 0 R ] /Contents 341 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1094,7 +1108,7 @@ endobj
 endobj
 192 0 obj
 <<
-/Contents 352 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 342 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1104,7 +1118,7 @@ endobj
 endobj
 193 0 obj
 <<
-/Contents 353 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 343 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1114,56 +1128,21 @@ endobj
 endobj
 194 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 207 0 R /XYZ 57.02362 750.5236 0 ] /Rect [ 208.2036 282.6236 233.2136 294.6236 ] /Subtype /Link /Type /Annot
->>
-endobj
-195 0 obj
-<<
-/Annots [ 194 0 R ] /Contents 354 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-196 0 obj
-<<
-/Contents 355 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-197 0 obj
-<<
-/Contents 356 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-198 0 obj
-<<
 /A <<
 /S /URI /Type /Action /URI (http://pygments.org/)
 >> /Border [ 0 0 0 ] /Rect [ 132.6236 696.0236 177.0836 708.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-199 0 obj
+195 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (http://pygments.org/docs/lexers/)
 >> /Border [ 0 0 0 ] /Rect [ 455.2536 543.6236 499.7236 555.6236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-200 0 obj
+196 0 obj
 <<
-/Annots [ 198 0 R 199 0 R ] /Contents 357 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 194 0 R 195 0 R ] /Contents 344 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1171,16 +1150,16 @@ endobj
 >> /Type /Page
 >>
 endobj
-201 0 obj
+197 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (http://pygments.org/demo/1817/)
 >> /Border [ 0 0 0 ] /Rect [ 77.02362 232.5736 218.2136 244.5736 ] /Subtype /Link /Type /Annot
 >>
 endobj
-202 0 obj
+198 0 obj
 <<
-/Annots [ 201 0 R ] /Contents 358 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 197 0 R ] /Contents 345 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1188,9 +1167,9 @@ endobj
 >> /Type /Page
 >>
 endobj
-203 0 obj
+199 0 obj
 <<
-/Contents 359 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 346 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1198,9 +1177,41 @@ endobj
   /Type /Page
 >>
 endobj
+200 0 obj
+<<
+/Contents 347 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+201 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://www.freedesktop.org/fontconfig/)
+>> /Border [ 0 0 0 ] /Rect [ 80.02362 144.8236 123.3836 156.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+202 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 204 0 R /XYZ 57.02362 141.5236 0 ] /Rect [ 336.2536 73.62362 464.6136 85.62362 ] /Subtype /Link /Type /Annot
+>>
+endobj
+203 0 obj
+<<
+/Annots [ 201 0 R 202 0 R ] /Contents 348 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
 204 0 obj
 <<
-/Contents 360 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 349 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1211,18 +1222,13 @@ endobj
 205 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (http://www.freedesktop.org/fontconfig/)
->> /Border [ 0 0 0 ] /Rect [ 80.02362 144.8236 123.3836 156.8236 ] /Subtype /Link /Type /Annot
+/S /URI /Type /Action /URI (http://tulrich.com/fonts/)
+>> /Border [ 0 0 0 ] /Rect [ 333.8236 671.8236 375.0768 683.8236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 206 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 141.5236 0 ] /Rect [ 336.2536 73.62362 464.6136 85.62362 ] /Subtype /Link /Type /Annot
->>
-endobj
-207 0 obj
-<<
-/Annots [ 205 0 R 206 0 R ] /Contents 361 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 205 0 R ] /Contents 350 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1230,9 +1236,19 @@ endobj
 >> /Type /Page
 >>
 endobj
+207 0 obj
+<<
+/Contents 351 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
 208 0 obj
 <<
-/Contents 362 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 352 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1242,14 +1258,32 @@ endobj
 endobj
 209 0 obj
 <<
-/A <<
-/S /URI /Type /Action /URI (http://tulrich.com/fonts/)
->> /Border [ 0 0 0 ] /Rect [ 333.8236 671.8236 375.0768 683.8236 ] /Subtype /Link /Type /Annot
+/Contents 353 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 210 0 obj
 <<
-/Annots [ 209 0 R ] /Contents 363 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 354 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+211 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 374.3936 417.8236 0 ] /Rect [ 177.9536 331.8236 266.8936 343.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+212 0 obj
+<<
+/Annots [ 211 0 R ] /Contents 355 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1257,29 +1291,9 @@ endobj
 >> /Type /Page
 >>
 endobj
-211 0 obj
-<<
-/Contents 364 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-212 0 obj
-<<
-/Contents 365 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
 213 0 obj
 <<
-/Contents 366 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 356 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1289,7 +1303,7 @@ endobj
 endobj
 214 0 obj
 <<
-/Contents 367 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 357 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1299,55 +1313,20 @@ endobj
 endobj
 215 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 216 0 R /XYZ 374.3936 417.8236 0 ] /Rect [ 177.9536 331.8236 266.8936 343.8236 ] /Subtype /Link /Type /Annot
->>
-endobj
-216 0 obj
-<<
-/Annots [ 215 0 R ] /Contents 368 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-217 0 obj
-<<
-/Contents 369 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-218 0 obj
-<<
-/Contents 370 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-219 0 obj
-<<
 /A <<
 /S /URI /Type /Action /URI (http://matplotlib.sf.net)
 >> /Border [ 0 0 0 ] /Rect [ 108.7236 708.0236 151.496 720.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-220 0 obj
+216 0 obj
 <<
-/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 576 /Length 5781 /SMask 221 0 R 
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 576 /Length 5781 /SMask 217 0 R 
   /Subtype /Image /Type /XObject /Width 432
 >>
 stream
 Gb"0N;6J\>G!nXbJ(*FR!sVCo;E"E.S;7UgE,MELo,dr4zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz!:KME!.UaBZu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?Zu/j@"WjQ?[-gh9"eMXk\*d.<"eMXk\*d.<"eMXk\*d.<"WjQ?[/O:ZG@&hu33&m]Wr!C,8%5MqEE#_D<VI_7O)@tlj/AQhWpWBM*o3jaa&,!Z8KEj]]t7;#O)+D@<cpV.p#oG!5E>#CXQk6;lHua!IN6ne=Om?Ue>$6urA^gTZ)[[5W(4=sqf,S2@oC@B;=AC&pZ#GjMcJSo5Wu\Yh2e=W)QUFkJU2F=\fXH81fe``!qkbXF[(oOBrpTK"R=C:l@'`'dob0!#h5VRec!!Ymp];k,>aG=<VPOPT#Reu8"^pZWp[o)4cNItO$Gk><S`_2H5`iq++\`[X1BBCoe]]l56CNA<cpX0e[nr6rFj]mS(-sfWi*,%q[obs\#T=F<)7"(pENLqDH6GkW1M#/mRNokh5]n`;*Bn=h2afa\lIRIC\9;\F[$f;mO!'=Np:>[l@&m$dB2\_*7`M?ebod'UKc:I33&m]Wr!C,8%5MqEE#_D<VI_7O)@tlj/AQhUlIs?hVFufa&,!Z<S`^$4h=YLO/%">X1BC(H??4!+%Pu\<cpV.p#oG!5E>#CXQk6;lHua!IN6neR+1Y>e@Sr8rO>ns@TE.I:lfKopZ&3D`iAGsTH;phm`/0fNE+eq5Wu\Yh2e=W)QUFkJU2F=\fXH81a[?-)YNN!F[*%Z]3*V^#h5VRebqJ-Vm39!&ZA4/Wr$d8:LdE!,>aG=<VPOPT#Reu8"^pZWp[o)4cN#RO%-gp<S`^Ooe'9f56CNA<cpWel=m?bIK\r`Xm1?Te^IXNr<UoJ>Li[3Wi*,%q[obs\#T=F<)7"(pENLqDH6Gk>.ohoh2afa\lIRIUO!iZ\fZKLFK;tp8+e]>F[#s#kZ2gjNp:>[l@&m$dB2\_*7`M?ebod'UKc:I\5r'-<VN7cmqu%Dj/AQhWpWBM*o3jaa&,!Z<S`^$4h=YLO/%">X1BC(H??4!+%Pu\<cpV.p#oG!5H`PK=Om@`e@V4"nMmPHZ)[[5W(4=sqf,S2@o`7J:lfKopZ&3D`iAGsTH;phm`/0fNE+eq5Wu\Yh2c@E/lm*Z)YNMFFZb]LBrpTK"R=C:l@'`'dob0!#h5VRebqJ-Vm39!&ZA4/Wr$d8:LdE!,>aG=<VPOPT#RRd8#+qsWp[p8H5EWn++\`[X1BBCoe]]l56CNA<cpWel=m?bIK\r`Xm1?Te^IXNr<UoJ>Li[3Wi%SNj3afL\#T=FXkq$smRNokh5]n`;*Bn=h2afa\lIRIUO!iZ\fZKLFK;tp8+e]>F[#s#kZ2gjNp:=Pl?G/Nh6#sk>cW(RWr!C,8%5MqEE#_D<VI_7O)@tlj/AQhWpWBM*o3jaa&,!Z<S`^$4h=YLO/%">P<'bEH?ZF$+4od`XQk6;lHua!IN6ne=Om?Ue>$6urA^gTZ)[[5W(4=sqf,S2@o`7J:lfKopZ&3D`iAGsTH;phm`2_](TY+hNI#f43Z^fa1fe``!qkbXF[(oOBrpTK"R=C:l@'`'dob0!#h5VRebqJ-Vm39!&ZA4/Wr$e<hSlM_8#+qsUlNJm4cNItO$Gk><S`_2H5`iq++\`[X1BBCoe]]l56CNA<cpWel=m?bIK\r`Xm1@?X*:hKqpD?d2lYhW<)7"(pENLqDH6GkW1M#/mRNokh5]n`;*Bn=h2afa\lIRIUO!iZ\fZKLFK;tp8+e\cFZ^T8mT+HpY1:-debod'UKc:I33&m]Wr!C,8%5MqEE#_D<VI_7O)@tlj/AQhWpWBM*o3jaa&,!Z8KEj]]t7;#O)+D@<cpV.p#oG!5E>#CXQk6;lHua!IN6ne=Om?Ue>$6urA^gTZ)[[5W(4=sqf,S2@oC@B;=AC&pZ#GjMcJSo5Wu\Yh2e=W)QUFkJU2F=\fXH81fe``!qkbXF[(oOBrpTK"R=C:l@'`'e!SYTB[jXuec!!Ymp];k,>aG=<VPOPT#Reu8"^pZWp[o)4cNItO$Gk><S`_2H5`iq++\`[X1BBCoe]]l56CNA<cpX0e[nr6rFj]mS(-sfWi*,%q[obs\#T=F<)7"(pENLqDH6GkW1M#/mRNokh5]n`;*Bn=h2afa\lIRIC\9;\F[$f;mO!'=Np:>[l@&m$dB2\_*7`M?ebod'UKc:I33&m]Wr!C,8%5MqEE#_D<VI_7O)@tlj''-S<S`^*]t6iVO/%">X1BC(H??4!+%Pu\<cpV.p#oG!5E>#CXQk6;lHua!IN6ne=Om?Ue>$6urA^gT0ra3\W->_Nqf/ap`N&>rTH;phm`/0fNE+eq5Wu\Yh2e=W)QUFkJU2F=\fXH81fe``!qkbXF[(oOBh[f:2!Wo!l@*!=GHn1F&ZA4/Wr$d8:LdE!,>aG=<VPOPT#Reu8"^pZWp[o)4cNItO$Gk><S`_2H5_u.*fYJiX1BD)l<ULVIK\r`Xm1?Te^IXNr<UoJ>Li[3Wi*,%q[obs\#T=F<)7"(pENLqDH6GkW1M#)N^ol$h5]n`[<`Xi\fZKLFK;tp8+e]>F[#s#kZ2gjNp:>[l@&m$dB2\_*7`M?ebod'UKc:I33&l2WT2C)GIOULENS*:WpWBPhVFufa&,!Z<S`^$4h=YLO/%">X1BC(H??4!+%Pu\<cpV.p#oG!5E>#CXQk6;lHua!IU&ptZ)[]KW-:2"j)J$o@o`7J:lfKopZ&3D`iAGsTH;phm`/0fNE+eq5Wu\Yh2e=W)QUFkJU2F=\f]Ph?**=?2!Wmkl?F<!dob0!#h5VRebqJ-Vm39!&ZA4/Wr$d8:LdE!,>aG=<VPOPT#Reu8"^pZWp[o)4cN#RO%-gp<S`^Ooe'9f56CNA<cpWel=m?bIK\r`Xm1?Te^IXNr<UoJ>Li[3Wi*,%q[obs\#T=F<)7"%a.lN#DH6Gk>.ohoh2afa\lIRIUO!iZ\fZKLFK;tp8+e]>F[#s#kZ2gjNp:>[l@&m$dB2\_*7`N*eF@5%]3Eha\5r'-<VI_7O)@tlj/AQhWpWBM*o3jaa&,!Z<S`^$4h=YLO/%">X1BC(H??4!+%Pu\-?VEhp$Pk'5H`PK=Om?Ue>$6urA^gTZ)[[5W(4=sqf,S2@o`7J:lfKopZ&3D`iAGsTH;phm`/0fNCb.O7_QE6h2c@E/lm*Z)YNMFFZb]LBrpTK"R=C:l@'`'dob0!#h5VRebqJ-Vm39!&ZA4/Wr$d8:LdE!,>aG=<VPNW]o,nHO%-gp8KEkeH5`iq++\`[X1BBCoe]]l56CNA<cpWel=m?bIK\r`Xm1?Te^IXNr<UoJ>Li\^<psKtpS1USDGnO8W1M#/mRNokh5]n`;*Bn=h2afa\lIRIUO!iZ\fZKLFK;tp8+e]>F[#s#kZ2gjY1:-debs12]3Eha\5r'-<VI_7O)@tlj/AQhWpWBM*o3jaa&,!Z<S`^$4h=YLO/%">X1BC(H??4!+%Pu\-?VEhp$Pk'5H`PK=Om?Ue>$6urA^gTZ)[[5W(4=sqf,S2@o`7J:lfKopZ&3D`iAGsTH;phm`/0fNCb.O7_QE6h2c@E/lm*Z!qkbXF[(oOBrpTK"R=C:l@'`'dob0!#h5VRebqJ-Vm39!&ZA4/Wr$d8:Ld;CUJ^Jt<VPNW]o,nHO$Gk><S`_2H5`iq++\`[X1BBCoe]]l56CNA<cpWel=m?bIK\r`Xm1?Te^IXNr<UoJ>Li[3Wi%SNj3afL2lYhW<)7"(pENLqDH6GkW1M#/mRNokh5]n`;*Bn=h2afa\lIRIUO!iZ\fZKLFK;tp8+e]>F[#s#kU(F7I\gAkWp[p:eVdY^rV2Y(*NQanhc;CJ<VPOPT#M#b$2M#UEN?Ym8+e]&TMES;eVdY^rA^gTZ)[[5W(/eGj7+Ym3^033aB-o5>Li]IQ$OGm:ab>)lFF%^If)gONXr'%nl>A<<cpWUV-_1Ie-YrNH>]dp+2:^WireS"HrW>=<S`_2H5`DQ=6+_nXf^l;r(=Y_c_rAb4n[B,F[(>O?H6^.(&=GICTG#g^J_8q1[9jF:VF/9h2bpBfC9`$7D>\Vg8aS]YLMn5N4L3?;@dVEpYuMO5X)%TaZ%^">Li]I5s:<jWC-4cou^<X5CQE>jC@J:HpbTQ<S`]Xe-#NB\g=hd-ap&PnUl-1T2`;\?M2$5F[(=UDreh$SD:%af;e8Zcg$L;=IkWpe`0i`rV/ZAOB^43\P'W;<S`]Xe-!6Sh3D3oZWboXpd%')]@:,s76R\C*KQiC)nAh:Q4L#$[As,oZ[*k*WrqrJoorL"5CQXOj;[C(Hq(fE<S`_.eJn=U\hpI66*%R=5H?a6D09dr?G2n$*KT)UcQr+QN1YO[^Y(QTEJM+I^SROD5NIi*?b#$DM3";+bNaQSQ?jlr<o<UNl=7!^If,LX->urBp/UBfY3LK6Q?jlr<o<UNl=3TSGl4^j.;r8Ep-%\6Y3LK6Y'MO8<o<U6l:\;FIf-?p.;r8Ep-%\6Y3LK6Y'MP#<?Lp7l=7!^If+bC/FQPFoi:9e:?m*%R<gOT<+#;]l:\;FIf,U[0CMkIof_S5Y3LK6R<gOT<+#;]l:\;FIf,U[0/$:soMt0dY3LK6R<gM><1ie_l=7!^If,U[0/$:soKDJ4Y3LK6Z$J/Y<1ieGl:\;FIf-Hs1+uV!oKDJ4Y3LK6NI!Ic;BPL1l=7!^If,1O26Tn"o2Y'cY3LK6NI!Ic;BPKnl:\;FIf-$g33Q4%o0)A3Y3LK6V0Y,);BPKnl:\;FIf-m*4"jI'nQ"jaY3LK6]m;an;4mAYl=7!^If-m*4"jI'nNH/1Y3LJ;l34jeIDbfX0=e+[Z)SW4#5&G_UV>fhm`2>6d,WX]I$OPqX1BAp:ljhnlKc,UIEY^INt80ZoPF3n?DTjJUlNL9e5L[tqK21'?ZK0@j(%@'4]m-DpS]aUWr)<XopQr$52*'ea'@0npnW41O&R4g<U+(sl@++_4fIPC0D6mg0dh*+DGeaF@HqpI7t&KZh2bdiZ[/#8>jkNsE`Mko0(lLkUH[2.eAkhErO>]fY%O]:"FNf>ffVNJ,2dh5s5mZihZrqbqUbOeeX$:<ouHYWWc%rLlL3o.;]c-ueXt4'U:pa!YGcrG9H>2L8(F6\pXH$jB;kj1]@:,;#HL(n&#^-CDc?[NJ#9@Pr3rVS]Do)&!UtU:HN8Q3rrrH'zzzzzzzzzzzzzzzzzzzzzz!;quZ"_FM*KE~>endstream
 endobj
-221 0 obj
+217 0 obj
 <<
 /BitsPerComponent 8 /ColorSpace /DeviceGray /Decode [ 0 1 ] /Filter [ /ASCII85Decode /FlateDecode ] /Height 576 /Length 6166 
   /Subtype /Image /Type /XObject /Width 432
@@ -1355,18 +1334,18 @@ endobj
 stream
 Gb"0WM8*,5*X;,_U)St.fe`=b7*$8n]>hSR;d$D,p1<T;ejrIOOtCI.?%aa8)1,n$ZU@EdHd?fq*l[pQ51fE)S`b>akB[(0T',d7f9j+`o:2!i+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ3T+sJ4/>4YcmGqF[)laBbBn%iE+HC%p6&C(c.Y'Fd7<=304;"r\"h4tmR%!Aa[lm@E?0%@Fp)qe3u@;)ll]tpjL#^o%1CTa;^<=31/;"n.[h4tmR$[&X?fhDh4LIS!*FY13t+ZpM)>feC;PsVu;e@D#B@ok+4I7)hk"1q,ZZjV#["5$<T@8`:cpZg)-;@(U&3`e(g?)8,/KfW;aam:L2cn3b\<b43=L=JZICO^Mk6C9f(W-e2K="/fh6CfVEcE:%N"%&QZnH=$#6Kf$H?7W7L'Z8Xum^4FS8KgcG*pR&JZE"\VX.dh(4O1*-#hK<nf6?R2KlBGYF"P@K;@FLt]%>6o-A>:P,1O<O@94n2[mQ]:H&,b&&8hu$YHdFDKlC"iF1#R<.>CP`h.p5<P@A2?l<^BpRhW_dU!AqYa0&;G[g0OsBC%+%E'gLE/\l7%$sSCrf2h5b`@ue?H_&)m;@"A"3`g>L]1O7%'C9$IYcAJT.A>&;RbabV\qIXrB6KJJ=<uD0NaXjqKJ,]`/%L@>V%=[RG-B<[.YVhBW,oAnCYA9_A#O`kaDOlaMhemqOmFEKn85+F,r`'/'Z-W]me%L18g0]Hl<JDq[;:-@/_%Jb@5fWiAOG;>&9a7((a&+PCtGnl'Z-'-cBZ&dY#5NALH8MCWU)*gY]m$mXhemQ$nI%C=*JhO6MN:fCY@;*?9d=4\L5u"T2ms"?jCqjIfHc_hr(Fdn>5<c=h0$[$[/_;g%gWCQ_*q_kKfZM("o%Hh["Voq*3O-1O!=t(1QGc!ag8f)EWH2,H/X!m.aW69@'L=H^u-k5,^tt5<HUlpsSbrm/39rY^;q_c>Njb^[$BSo4O*$MX8.(DZp'Sl\!md1Ugg^Jj#&i@96nqK=t"ip(#RsgqssDp,l;1h!=#t/[8s`_EEiT=\U5/28d+&%b1mNO^>iKDmV9#o*0C;9M_`\Y]&T&fKNE^,MDlK"0j&d^6)K*QXD[0AEV9HcgZYc7UCcXK5/uEAEU/FHob4Pgc+dRX3pZ<c$.h91EE/1iP(FU@EW%9De8+XoY?=eqaOnGm>BFVQCU5r!%Y>^4290g=NsRnq(jZi4XN+!k;R](]@VGsr,q.h!qdDHc>W@j<:_>Xr(MI98(sT+he4aGk2#D%RBBYS"5*F/[_lkZPFXpZ"]hE$4290W=Nt^8q(p>`4f25ao,HMDh(..T>u6M.69SX`kI::%WYt7'/uTMY*pIh6r'p9f28d,b"go.Ij=kb+UFia>_;=V^]*Kpm*]q+K\.Ar>IM^WM:ljnPg%gVFa6p>\4+@J3f%HPZpf?iL292u^B>AGV%:\KZRMU=HBIGrl#5m%TY`I@7fZ%%<54&1bn69PA5$Cln]s4#QZL__EDk.(/BMF0i_J66hcC_qeFVaD?2&5g3<-)MYG5aP\\'Dj=[&1.a%%%!Sh(.,JCFT`4/mloLT/dW:''uAN($9,<49R1?!'@rXS)Noc:leE*nZBG4QeObgdX0[CNPO.t`A:cU!k[&um/0=jL<IVI7CHdj2f^]Z*fLhJbKb%eB"0r-lL>TN^=@:$c(C^J/q^no4Nu)heDs,uk%j>])=U^^F4pAKg^KOc?Q"#qk;RE;>eUe#Z8=YXOdk>#)c2Ua2-eECpaa5qm/0=jL<JMY$l?2?)n?h=K>0/EH]*9*\J[#P+!1g_(AS;!(TSG"E#JQJaH+_2e51mdiA10Y_mA_-<aLO(i3*PjYk&gE)(pQV13@*j2f^]Z#(L2tcd$IiB"3fuatP]ALDn>)10b$5AU''&hoa,])>ob.!'@rXS)H-t.mjhjIO"?EU3MF9i3*P0g%gWCiA0e)A\[g^eDmGeg%gW?%$qomLO-o1:dZ+,L<JMY$j52YNSFr/_-\(+ZL]$G)(pQF8+"7?DrbN?r!:dsSqe6,E&1bu)X7p\6OdUO)(pQV1;rc\6YUFmbM]Q4nN>;tR[`:,kua(mf_LN^%%$G#MF@&46Q'crbF_'`id%Jr%.'+NG_XBL5Wp<;W1c';OeNZFq(psp;<)r#Ten^GjV+mCnN>;tR[`:,*E\GXg%gW_%%#k,HGoDO6Q'3bbH7EY&O"W?R[`:,-J6#kH)RDn2oFaPYTiVMNP./-_r[Al,"o03)dSEQN+]Zu(=_AKG'ken_r\G0Td#Q&o,G4X0!>fYM!1OedbG7t&&X:k_9Qu[B"34/<b-K!INpehj]A)r';BcNTaWTljf3#kO/L\,Xh5(/f7\IGQa--$\J["AL_\U(S_n*bXCaT0nb'q[XNJh,":gd1Yk)Ks5WpGQA`l!m1L-LSolu%Yhoa,]Gnm8JH5/NVOdk>#ITV^7g%gW_%$rWbMQFqFDrbN?r"RXjH5/NVOdk>#%oA>eZL_:G)(mQIogo,-c>VcU\@anHYJ]&hNPONDL$\`*$a:i@Zh#-H)(n,\or+IOS_qN5E;:HOa'7p*<nOkmiYa@%%eWA2B'2)SLWe#Jo4N6^mWC?J^QG#EnsNUB^TmAL\J[$WNtlBRc>VcU\GSA:j*c)u.keg%"ed"%*UN\nDMH>=A+r$HS_qN5E;=%GaB%[*7W*t(G@<oUAEPo:LXh>r\GRN"j"kk+.r`!<c-(rJ6Trlpf_LN^%$s%cpH"k9hoO&]q&$3SG3o,rDMH?D?pti@k;RE;>TO@IpmN5\b0+b7"ZBV7KUq#Ac#@q1W(2.T426oIiURR_O^6Z9NHW-Q`\Ul6*\4N)422@e>`S"/`32Kj`]%Ai2tA_/DE]*+0oV[\b0+aL/Z;0c#s5naS)Np(=HS$aq2O/<Q`nDdXN\t.jCYna''f!s'6\gL0>lnKPG'&DZ1D1F)(r)sogntbo,G4X0(4i9l,M"e":gdEB'7M4`JUb5c>VcU\3(br0sql\^QFlAEoRI&O-ePqXi<U`^LP=1X8qoaY@6TQ!f+s[Zh%i'`9qaR426oIiGp$Aa?&\c7W*t(6_PRk4@<8+S)NotW5fkDpf:^Ub=b/bdMpm8NSFr/GJ`duMk/bHc#EJpXN3ltr'kRYb7?j$C?Asf2nB4*=$4C^0;'BTZK#/7)(mQDogj"2k;RE;>jd4"lZdT%,<*O%;m7I8Zh#-H)(sg!'ktS2DrbN?r"7H=@s35M0>loITH<>\m/0=jL<H&ppH"#!hoO&]q)GHH4O6ii[Pq5CT&K6W=HQ&*q2N2KE[Q&0bWAX^Z0_6d?A?WTZ%j5=AEPml1L0>Non_fLb0o&RQ[<11id$9a1cN>6JQS%JStR^Qc#EK$W(/tr:mU'P\;WT#&C3.sAU#(FGD(91oF,;FD6]Q"%$u<K7H/TIZ8?O1*7#__#%0mZH%rU]2oFaDTH<Vc6Wo/1iURseTH;#(q5q:<QeOkjd_>)G7W*t(?*PUD4@<8?S)NoQ=HRj"Te+I5E;<Y8a-<Ifr'kRYb7gQj,MDmp]F:-.JpO4oZh#-H)(tB3h<Q2,INpehjbp>eCU*IM\J["a!VMi:S=SR$7dOIOr6amnW5kt*pf:^Ub=b2cdd,T^NSFr/GK0&n"?XA\S)Nou=HO'Fq2O/<QQLg*<4?8u2f^]Z*XhXcRiUD/bA\>HW8SM8INpehAalCJA(^U:g^KNF`JSbLk;V[\eVn.N49R1_R[r=A*%lGGkKeMWp%X%Xhoa,]\II%5]p##EaN\ZAI&Q!LG((Yp_e&>2L99/)NSFr/#@g1<@co[j1L.p@CA=;>hoa,])18CA5OA;;DMH?m6Od\4o,E7qn\m:h"s7U4St4aE*%i>RcCY-p`r9%_INpehAaH+FDqOT^]F:.CLDh4FkI:";>Qu9b31lc!aN\ZAI&LI4G((Yp_rY[=,0R:`)n?h=@h1GUDoBq>jCPh051K'I422O()db_FAalCJ9A0-#^u9;rD[Q^*`kF)f^QG#Ens*=>G3o,rDMH?\6TlbR@HTQNJ)cH!\D1U-eDkgtIOd(hAalCJ/(s`Xg^KPD_=#jES_qN5E;:-J8-a<e,<*O%-_VU1R^)H'Go84n)@uKX`QiD`A[i/_NW!%(INpehj^#-<*QlZGjCYoL*`cfWG(-2RYaY(jQQLd)<6rP/DZgQ:gU$Ka^4psHac:<$A[qY>W(/n)S_qN5E-XP3?G5%fNSFr/_1rpeB'2*n1L.r6\6LgC426oIiUVb#O"p"r<aLO(o0PUg_<h(hDMH=R@J;g6S_j^#3H71!jWguR>Hm]<J]$T@m/3:;YTi\Fo,G4X/n<caqMZHPb0+b71%q]n_sI:jDMH?mUA#jTINpehAT2)lc`[bR\J[#Pcb)0#Ns)s1/n79?R^q,INP#[dP>P/;:YG9?]F:.Cs*5I-6R\d^_rZ6tq(kZO7;c`#2f^]ZhAe%d/j$h1S)NpH=HRiW`@K3VE&m0@'oD*<Gbnidjg"1I^VW1OOfm$UDrYH>S@jV7=dbi<`m&J5.J?G\g6Q$[`m&IJ.BH(o5X%g$A[n7P#4KOVDrbK>N4sN]D&=oME\grqc3!Ib0](mKB"4Ad"PtYt&O8q$Y`eMbQ]l'tHSpb#/q_('("rD4oauGP"ka&Q]F:-j7bG^-9ikmbY])C':)3iUQ#=lb@,Y_-S?.b-CEI^%$TGubU^MLP#4W]D2oFb<5kJ@li]B)*L<E//14$-Yn/Wr:_rW/S'YRSZ0Y9Ysi4l)J)(rg6\XB-1]0^f$E4H38s"(s`-tddT?(jA>_e!p_<,67HF)s"PjV^74n!3TUG::MVE-[1Xpq8kPrD1.FL<DAHa7#97c7VtKS)JCN1_4Q.FPNVW)Pst^/dM/mn'<&7qk4"/\3(9`s"(sJBUr)T4\G9#>Ya5G"D!O*(F]C_cfAs0r3L,[k$2VH7Q`oOrg'&4ndK;h\^h2,U4(D?c#@r_otqcMf!qJ"I>tG"iGnuaQT)N0Hi8ZSkPt'->ctJ+TMteug3n=43*Fd@CMeFfR5a4)k>O=Wj]\4lgh@N]Dd@SVVTW#bo$<],h.GKg*;%b8Fas81Grsqr\6LQB^V=AZ1Nq!C,DJAObfJ1=rUqmNj)V<dB"2*H,?EsQ(n,Nb+^!NEL<HtcKXjBsoZ=Y<S)JCi:k.B$LHY3FfEOtfd;ZW3pgo4FA,1Kk\f!.#XEBmLeAHs0s)<*C(,qiDo$<bX3C5kkST@/;\@bedEQc0>D>4bsbIO:8iUTYaKXl]jIei^/1L-O9fg'1(>:&0UIYQ$%h%f&ZAs8_HgX"2bGp`%.f6SBuF$Dn,jdD,<EsAuM3VRSN>lM_9JaQog5ecph%$uGE55SN%*V->A%[K#IiUSY%Wl*W.BNeF380NQ%jf\EV[<OdW+cJnPgs45b\ILgUX,h%;DWbZB>c25-9@t5QD`L>*jZ;]2\qJ=Sq3H(Y>cuOl@[KfU<9O18U8-[fk5I'40R5J;DN9IpR6:KQ2CRa+NeY`FAHL])U3F?%)ESiis(Z);@i0$PD_pmD2ZrYGCXkMj/IZB7IeA>giUSN8RMP$(jc.BmRA8a3XME_LliuWXbgCBT<q&1$Xn#fC3Z9Wsk.s=W-n"2%a*JXVc__`Xbo<]Aq:>*n>b57$0_[!Uj.'>!)D9@='fP&*b'U,oIYf\WiUUo/`ZD1faa:$I(.t(jIiHlJptm)=3DUAq%@;RFn_IVk;G,5579@CghjNea0LtqK?fp/-<%Mol_r]ck2'U+Ar`B8Id;OXmcg]*6lR[3FDjh3<ke2.Mp[b;,LtBQDOX8ZI*:!$>`Qn-.]:2Gnk=hl!\UM,I?-T@FD@_5uBb)5GoA=kPUuRQ0J"<#^AH16I9$XP`9q\CTCIXl(8MbOZ,&#XM?D?&a0jsI)nb$!+g)ft?T7.Dc_Q^AUd=2JbY/Q^i5$-'e8'QC)S[RS,EIU6h[:ZI`]mT%aj_'sEhKc&,n*SgtqU4K"WEO$%mO.b@j7*pUIkbBScc<)Xr56"9Numi4huS7dft6iJXk3rVKK5JipSJ$)&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5Te&J5TeX8`38(n@c~>endstream
 endobj
-222 0 obj
+218 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://tobi.oetiker.ch/lshort/lshort.pdf)
 >> /Border [ 0 0 0 ] /Rect [ 210.6636220472441 350.6236220472442 374.07362204724416 362.6236220472442 ] /Subtype /Link /Type /Annot
 >>
 endobj
-223 0 obj
+219 0 obj
 <<
-/Annots [ 219 0 R 222 0 R ] /Contents 371 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 215 0 R 218 0 R ] /Contents 358 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.0ba901e64a80f2e0e4e27e23b621fb7f 220 0 R
+/FormXob.0ba901e64a80f2e0e4e27e23b621fb7f 216 0 R
 >>
 >> /Rotate 0 
   /Trans <<
@@ -1374,9 +1353,9 @@ endobj
 >> /Type /Page
 >>
 endobj
-224 0 obj
+220 0 obj
 <<
-/Contents 372 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 359 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1384,16 +1363,16 @@ endobj
   /Type /Page
 >>
 endobj
-225 0 obj
+221 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (http://web.chad.org/projects/smartypants.py/)
 >> /Border [ 0 0 0 ] /Rect [ 132.0636 708.0236 186.5236 720.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-226 0 obj
+222 0 obj
 <<
-/Annots [ 225 0 R ] /Contents 373 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 221 0 R ] /Contents 360 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1401,16 +1380,53 @@ endobj
 >> /Type /Page
 >>
 endobj
-227 0 obj
+223 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (http://sphinx.pocoo.org)
 >> /Border [ 0 0 0 ] /Rect [ 57.02362 708.0236 87.59362 720.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
+224 0 obj
+<<
+/Annots [ 223 0 R ] /Contents 361 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+225 0 obj
+<<
+/Contents 362 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+226 0 obj
+<<
+/Contents 363 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+227 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/rst2pdf/rst2pdf/tree/main/rst2pdf/extensions)
+>> /Border [ 0 0 0 ] /Rect [ 57.02362 666.0236 104.8236 678.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
 228 0 obj
 <<
-/Annots [ 227 0 R ] /Contents 374 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 227 0 R ] /Contents 364 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -1420,27 +1436,24 @@ endobj
 endobj
 229 0 obj
 <<
-/Contents 375 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/A <<
+/S /URI /Type /Action /URI (https://github.com/rst2pdf/rst2pdf)
+>> /Border [ 0 0 0 ] /Rect [ 202.0936 708.0236 232.1036 720.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 230 0 obj
 <<
-/Contents 376 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Annots [ 229 0 R ] /Contents 365 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
+>> /Rotate 0 
+  /Trans <<
 
->> 
-  /Type /Page
+>> /Type /Page
 >>
 endobj
 231 0 obj
 <<
-/Contents 377 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
+/Contents 366 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -1450,112 +1463,20 @@ endobj
 endobj
 232 0 obj
 <<
-/Contents 378 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/Border [ 0 0 0 ] /Contents () /Dest [ 157 0 R /XYZ 507.7036 662.0236 0 ] /Rect [ 63.02362 706.6772 68.58362 718.6772 ] /Subtype /Link /Type /Annot
 >>
 endobj
 233 0 obj
 <<
-/A <<
-/S /URI /Type /Action /URI (https://github.com/rst2pdf/rst2pdf/issues)
->> /Border [ 0 0 0 ] /Rect [ 216.7636 657.0236 393.5136 669.0236 ] /Subtype /Link /Type /Annot
+/Annots [ 232 0 R ] /Contents 367 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 318 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
 >>
 endobj
 234 0 obj
-<<
-/Annots [ 233 0 R ] /Contents 379 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-235 0 obj
-<<
-/A <<
-/S /URI /Type /Action /URI (https://github.com/rst2pdf/rst2pdf)
->> /Border [ 0 0 0 ] /Rect [ 148.1736 708.0236 293.8036 720.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-236 0 obj
-<<
-/A <<
-/S /URI /Type /Action /URI (https://pre-commit.com/)
->> /Border [ 0 0 0 ] /Rect [ 130.9536 279.162 184.5147 291.162 ] /Subtype /Link /Type /Annot
->>
-endobj
-237 0 obj
-<<
-/Annots [ 235 0 R 236 0 R ] /Contents 380 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-238 0 obj
-<<
-/A <<
-/S /URI /Type /Action /URI (https://pymupdf.readthedocs.io/en/latest/)
->> /Border [ 0 0 0 ] /Rect [ 319.3136 699.0236 364.1946 711.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-239 0 obj
-<<
-/A <<
-/S /URI /Type /Action /URI (https://mupdf.com/)
->> /Border [ 0 0 0 ] /Rect [ 472.7136 699.0236 505.5474 711.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-240 0 obj
-<<
-/A <<
-/S /URI /Type /Action /URI (https://www.reportlab.com/)
->> /Border [ 0 0 0 ] /Rect [ 361.6236 687.0236 410.4325 699.0236 ] /Subtype /Link /Type /Annot
->>
-endobj
-241 0 obj
-<<
-/Annots [ 238 0 R 239 0 R 240 0 R ] /Contents 381 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-242 0 obj
-<<
-/Contents 382 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-243 0 obj
-<<
-/Border [ 0 0 0 ] /Contents () /Dest [ 162 0 R /XYZ 507.7036 692.0236 0 ] /Rect [ 63.02362 706.6772 68.58362 718.6772 ] /Subtype /Link /Type /Annot
->>
-endobj
-244 0 obj
-<<
-/Annots [ 243 0 R ] /Contents 383 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 331 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 
-  /Trans <<
-
->> /Type /Page
->>
-endobj
-245 0 obj
 <<
 /Length 1861
 >>
@@ -1575,37 +1496,37 @@ begincmap
 endcodespacerange
 128 beginbfchar
 <00> <0000>
-<01> <0001>
-<02> <0002>
-<03> <0003>
-<04> <0004>
-<05> <0005>
-<06> <0006>
-<07> <0007>
-<08> <0008>
-<09> <0009>
-<0A> <000A>
-<0B> <000B>
-<0C> <000C>
-<0D> <000D>
-<0E> <000E>
-<0F> <000F>
-<10> <0010>
-<11> <0011>
-<12> <0012>
-<13> <0013>
-<14> <0014>
-<15> <0015>
-<16> <0016>
-<17> <0017>
-<18> <0018>
-<19> <0019>
-<1A> <001A>
-<1B> <001B>
-<1C> <001C>
-<1D> <001D>
-<1E> <001E>
-<1F> <001F>
+<01> <0000>
+<02> <0000>
+<03> <0000>
+<04> <0000>
+<05> <0000>
+<06> <0000>
+<07> <0000>
+<08> <0000>
+<09> <0000>
+<0A> <0000>
+<0B> <0000>
+<0C> <0000>
+<0D> <0000>
+<0E> <0000>
+<0F> <0000>
+<10> <0000>
+<11> <0000>
+<12> <0000>
+<13> <0000>
+<14> <0000>
+<15> <0000>
+<16> <0000>
+<17> <0000>
+<18> <0000>
+<19> <0000>
+<1A> <0000>
+<1B> <0000>
+<1C> <0000>
+<1D> <0000>
+<1E> <0000>
+<1F> <0000>
 <20> <0020>
 <21> <0021>
 <22> <0022>
@@ -1708,7 +1629,7 @@ CMapName currentdict /CMap defineresource pop
 end
 endendstream
 endobj
-246 0 obj
+235 0 obj
 <<
 /Length 11172 /Length1 11172
 >>
@@ -1728,16 +1649,16 @@ loca¿M…“  (@   ƒmaxp Ö=  )    name‹`ÆÖ  )$  _post     +Ñ     ∞ê         
 ™
 ÿ\åºﬁ$J`zÆﬁHÄ¥ÍLÜ∏ﬁBt¢ŒÙ*`à∂Ù*`à¿ÿB^    a; #                        ∆        	          	                                        %       	 (  	   n 1  	   ü  	   ∑  	  2 ≈  	   ˜  	    	  '  	  P=CopyrightNewRegularNewNewVersion 1.00NewTrademark C o p y r i g h t   ©   1 9 9 9   b y   M a t t h e w   W e l c h .   A l l   R i g h t s   R e s e r v e d . W h i t e   R a b b i t R e g u l a r W h i t e   R a b b i t : V e r s i o n   1 . 0 0 W h i t e   R a b b i t V e r s i o n   1 . 0 0 W h i t e R a b b i t W h i t e   R a b b i t ô   T r a d e m a r k   o f   M a t t h e w   W e l c h                                            endstream
 endobj
-247 0 obj
+236 0 obj
 <<
-/Ascent 666.6667 /CapHeight 666.6667 /Descent -95.2381 /Flags 4 /FontBBox [ 47.61905 -95.2381 523.8095 666.6667 ] /FontFile2 246 0 R 
+/Ascent 666.6667 /CapHeight 666.6667 /Descent -95.2381 /Flags 4 /FontBBox [ 47.61905 -95.2381 523.8095 666.6667 ] /FontFile2 235 0 R 
   /FontName /AAAAAA+New /ItalicAngle 0 /MissingWidth 571.4286 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-248 0 obj
+237 0 obj
 <<
-/BaseFont /AAAAAA+New /FirstChar 0 /FontDescriptor 247 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
-  /ToUnicode 245 0 R /Type /Font /Widths [ 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 
+/BaseFont /AAAAAA+New /FirstChar 0 /FontDescriptor 236 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
+  /ToUnicode 234 0 R /Type /Font /Widths [ 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 
   571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 
   571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 
   571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 
@@ -1752,9 +1673,9 @@ endobj
   571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 571.4286 ]
 >>
 endobj
-249 0 obj
+238 0 obj
 <<
-/Length 1894
+/Length 1882
 >>
 stream
 /CIDInit /ProcSet findresource begin
@@ -1768,41 +1689,41 @@ begincmap
 /CMapName /AAAAAA+DejaVuSans def
 /CMapType 2 def
 1 begincodespacerange
-<00> <80>
+<00> <7F>
 endcodespacerange
-129 beginbfchar
+128 beginbfchar
 <00> <0000>
-<01> <0001>
-<02> <0002>
-<03> <0003>
-<04> <0004>
-<05> <0005>
-<06> <0006>
-<07> <0007>
-<08> <0008>
-<09> <0009>
-<0A> <000A>
-<0B> <000B>
-<0C> <000C>
-<0D> <000D>
-<0E> <000E>
-<0F> <000F>
-<10> <0010>
-<11> <0011>
-<12> <0012>
-<13> <0013>
-<14> <0014>
-<15> <0015>
-<16> <0016>
-<17> <0017>
-<18> <0018>
-<19> <0019>
-<1A> <001A>
-<1B> <001B>
-<1C> <001C>
-<1D> <001D>
-<1E> <001E>
-<1F> <001F>
+<01> <00B1>
+<02> <0000>
+<03> <0000>
+<04> <0000>
+<05> <0000>
+<06> <0000>
+<07> <0000>
+<08> <0000>
+<09> <0000>
+<0A> <0000>
+<0B> <0000>
+<0C> <0000>
+<0D> <0000>
+<0E> <0000>
+<0F> <0000>
+<10> <0000>
+<11> <0000>
+<12> <0000>
+<13> <0000>
+<14> <0000>
+<15> <0000>
+<16> <0000>
+<17> <0000>
+<18> <0000>
+<19> <0000>
+<1A> <0000>
+<1B> <0000>
+<1C> <0000>
+<1D> <0000>
+<1E> <0000>
+<1F> <0000>
 <20> <0020>
 <21> <0021>
 <22> <0022>
@@ -1899,24 +1820,25 @@ endcodespacerange
 <7D> <007D>
 <7E> <007E>
 <7F> <007F>
-<80> <00B1>
 endbfchar
 endcmap
 CMapName currentdict /CMap defineresource pop
 end
 endendstream
 endobj
-250 0 obj
+239 0 obj
 <<
 /Length 35580 /Length1 35580
 >>
 stream
-     Ä  POS/2Y-v-   ‹   Vcmap	X
-y  4  cvt  i9  L  ˛fpgmq4vj  L   ´glyf
-O∫   ¯  @∞head]¬Ü  E®   6hheaüÕ  E‡   $hmtxÀ}4Ô  F  ÇlocaÂ@ˆ∏  Gà   ƒmaxpŒq  HL    namemM°  Hl  =postˇÅ Z  Öt    prep;Ò   Öî  h ê   3ô  3ô  ◊ f  Á nˇ“ ˝ˇ
-$`)  PfEd @  ˇˇ˛öm„` ˇﬂˇ                   Å                                                                         	 
-                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _   `5 ∏ À À ¡ ™ ú¶ ∏ f   q À †≤ Ö u ∏ √Àâ- À ¶  ” ™ á À™ J 3 À   Ÿ ÙT ¥ ú99 N¥R∏ÁÕ 7sÕ`s3¢V¶V9≈ …  ∏ﬂ s ∫È3ºD ﬂÕ™ Â™   À è § { ∏ o {R è «Õ ö ö o À Õû”  ∫É ’ òH û’ ¡ À ˆ ÉT  3f ” « § Õ è ö s ’
- ˛+ § ¥ ú   b ú   -’’’  { T §∏#” ∏ À ¶√Ïì † ”\q€Ö#®H è99` è’ö#fy```{ ú  w`™ È`b { ≈ {   ¥RÕ f º f w Õ;Öâ è {    ÕJ/ ú ú  } o   o5 j o { Æ ≤ -ñ è{ ˆ ÉT7ˆ è ú·f èçˆ ÕD ) fÓ s    ñ  ∑ , ∞%Id∞@QX »Y!-,∞%Id∞@QX »Y!-,  ∞ P∞y ∏ˇˇPXY∞∞%∞%#· ∞ P∞y ∏ˇˇPXY∞∞%·-,KPX ∞˝EDY!-,∞%E`D-,KSX∞%∞%EDY!!-,ED-,∞%∞%I∞%∞%I`∞ ch ää#:äe:-   f˛ñf§   @˚ ˚ /ƒ‘Ï1 ‘Ï‘Ï0!%!!f ¸s¸Â˛ñ¯Úr) 5   ’  	 5@ ÉÅ  
+     Ä  POS/2Y-v-   ‹   Vcmap	á
+G  4  cvt  i9  L  ˛fpgmq4vj  L   ´glyf
+O∫   ¯  @∞head]¬Ü  E®   6hheaüŒ  E‡   $hmtx—X5»  F  Ñloca‡‚Ô‡  Gà   ƒmaxpŒq  HL    namemM°  Hl  =postˇÅ Z  Öt    prep;Ò   Öî  h ê   3ô  3ô  ◊ f  Á nˇ“ ˝ˇ
+$`)  PfEd @  ˇˇ˛öm„` ˇﬂˇ              
+     Ä                                                                       	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ `    5 ∏ À À ¡ ™ ú¶ ∏ f   q À †≤ Ö u ∏ √Àâ- À ¶  ” ™ á À™ J 3 À   Ÿ ÙT ¥ ú99 N¥R∏ÁÕ 7sÕ`s3¢V¶V9≈ …  ∏ﬂ s ∫È3ºD ﬂÕ™ Â™   À è § { ∏ o {R è «Õ ö ö o À Õû”  ∫É ’ òH û’ ¡ À ˆ ÉT  3f ” « § Õ è ö s ’
+ ˛+ § ¥ ú   b ú   -’’’  { T §∏#” ∏ À ¶√Ïì † ”\q€Ö#®H è99` è’ö#fy```{ ú  w`™ È`b { ≈ {   ¥RÕ f º f w Õ;Öâ è {    ÕJ/ ú ú  } o   o5 j o { Æ ≤ -ñ è{ ˆ ÉT7ˆ è ú·f èçˆ ÕD ) fÓ s    ñ  ∑ , ∞%Id∞@QX »Y!-,∞%Id∞@QX »Y!-,  ∞ P∞y ∏ˇˇPXY∞∞%∞%#· ∞ P∞y ∏ˇˇPXY∞∞%·-,KPX ∞˝EDY!-,∞%E`D-,KSX∞%∞%EDY!!-,ED-,∞%∞%I∞%∞%I`∞ ch ää#:äe:-   f˛ñf§   @˚ ˚ /ƒ‘Ï1 ‘Ï‘Ï0!%!!f ¸s¸Â˛ñ¯Úr)  Ÿ  €   .@–ú –	ú 
+‘<Ï2¸<Ï21 /Ï‘<Ï¸<Ï0!!#!5!!!Æ-˝”®˝”-˝”˙˛˛}™˛}É™É˚¶™   5   ’  	 5@ ÉÅ  
 ¸K∞TXπ  ˇ¿8Y<Ï2991 /‰¸Ã0∂  P]%3#3#5ÀÀÀ¢˛˛’˝q˛õe     ≈™È’   B@Ñ Å ¸K∞TK∞T[Xπ ˇ¿8Y¸‹Ï1 Ù<Ï20@0	@	P	`	p	†	ø	]#!#o™$™’˝’+˝’+    û  æ   `@1 á	á	 
  ¸Ã91 /<‘<<¸<<‘<<ƒ2Ï220@]!!!3!!!!#!#!5!!5!˛›T%Dh$i†g8˛°R>˛õh†g˛€g°h˛≈`T˛æifÖ˛≤á˛aü˛aö˛≤ô˛bû˛bûôNöü   ™˛”m ! ( / Ω@U"
 
@@ -2132,10 +2054,9 @@ ii`{xxâ ä	ÖÖâââô	ïïöö§§´´∞œﬂˇe] ]+5326?3	3ìNî|ìlL
   C
 %‘K∞TXπ  @8Y<ƒ¸<ƒ299999991 ¸ÏƒÙÏÓ99999990≤ &]#"&=4&+5326=46;#"3>˘©lé==èk©˘>DçV[noZVçæêî›Ôótèsï›ìèXç¯ùééú¯çX  ˛Æ  ∑ ± ‘Ï1 ¸Ã0#Æ™¯       ˛≤ $ á@6%  © ©#¿©±% # C %‘K∞
 TXπ ˇ¿8YK∞TXπ  @8Y<ƒ2¸<ƒ99999991 ¸ÏƒÙÏÓ99999990≤ &]326=467.=4&+532;#"+ FåUZooZUåF?˘ßlé>>élß˘?æVè¯úééù¯éWèì›ïsètóÔ›î   Ÿ”€1  #@ úú ‘ƒ1 ‘¸‘Ï¿990#"'&'&'&#"5>32326€i≥aníõ^X¨bi≥anì
-õ^V©1≤OD;>MS≤OE<>L   Ÿ  €   .@–ú –	ú 
-‘<Ï2¸<Ï21 /Ï‘<Ï¸<Ï0!!#!5!!!Æ-˝”®˝”-˝”˙˛˛}™˛}É™É˚¶™      YôcU
-Å_<ı      —~‰    —~‰˜÷¸LY	‹              m˛  ˛˜÷˙QY                `Õ fã  55Æ ≈¥ û ™ö q= Å3 ≈ ∞ §  =¥ Ÿã û„ dã €≤   á · ñ ú d û è ® ã Å≤ ≤ û¥ Ÿ¥ Ÿ¥ Ÿ? ì  áy } …ñ s) … …ö …3 s …\ …\ˇñ? …u …Á …¸ …L s” …L sè … á„ˇ˙€ ≤y È D{ =„ˇ¸{ \ ∞≤   «¥ Ÿ ˇÏ  ™Á { ∫f q qÏ q— / q ∫9 ¡9ˇ€¢ ∫9 ¡À ∫ ∫Â q ∫ qJ ∫+ o# 7 Æº =ã Vº ;º =3 X ≤ ¥ Ÿ Ÿ     " " T ä ˆ¢6jîÃ¯Fpå¢∂‹V÷J®t∫$éÆ÷		4	p	‹
-úræ˛.X¨⁄˛6 ÏjæD™4∞Ë*öx ,åº‚.DlNöÊPú <d¢8ö÷(x» ∞Ó0¬‘ñ|‚Phﬁ   X    aT + h    ô        >        ò2       „       ˘              :       `       
+õ^V©1≤OD;>MS≤OE<>L     Yô_˝·_<ı      —~‰    —~‰˜÷¸LY	‹              m˛  ˛˜÷˙QY                aÕ f¥ Ÿã  55Æ ≈¥ û ™ö q= Å3 ≈ ∞ §  =¥ Ÿã û„ dã €≤   á · ñ ú d û è ® ã Å≤ ≤ û¥ Ÿ¥ Ÿ¥ Ÿ? ì  áy } …ñ s) … …ö …3 s …\ …\ˇñ? …u …Á …¸ …L s” …L sè … á„ˇ˙€ ≤y È D{ =„ˇ¸{ \ ∞≤   «¥ Ÿ ˇÏ  ™Á { ∫f q qÏ q— / q ∫9 ¡9ˇ€¢ ∫9 ¡À ∫ ∫Â q ∫ qJ ∫+ o# 7 Æº =ã Vº ;º =3 X ≤ ¥ Ÿ   " Z Z å ¬.⁄n¢Ã0~®ƒ⁄ÓVéÇ‡@¨Ú\∆Ê		J	l	®
+
+‘R™ˆ6fê‰6n$¢ˆ<|‚lË b“∞dƒÙDf|§:Ü“à‘8tú⁄Rp“`∞ 8Ë&h˙Œ¥à†  X    aT + h    ô        >        ò2       „       ˘              :       `       
 É       ≤              ù(Z       4;b       ;Ø       ;≈  	  0    	  À  	  Ô  	  ˛  	  "  	  F  	  m  	  "é  	  :ƒ  	 %:  	  h:¯  	  ;ó  	  ;ª C o p y r i g h t   ( c )   2 0 0 3   b y   B i t s t r e a m ,   I n c .   A l l   R i g h t s   R e s e r v e d . 
  C o p y r i g h t   ( c )   2 0 0 6   b y   T a v m j o n g   B a h .   A l l   R i g h t s   R e s e r v e d . 
  D e j a V u   c h a n g e s   a r e   i n   p u b l i c   d o m a i n 
@@ -2339,16 +2260,16 @@ from Tavmjong Bah. For further information, contact: tavmjong @ free
 WW2V˛UTUBTSSRQJQ˛PO˛NMN˛ML˛KJK˛JIJIIHG˛FñEñD˛C-C˙BªAK@˛?˛>=>=<=<;<@ˇ;:˛9˛878˙767656543212˛10/0/.-	.-	,2+*%+d*)*%)('%(A'%&%&%$˛#˛"!! d˙dB˛˙BB˛d˛˛˛˛B˛-B}d˛˛˛
 	˛-˛d˛@-˛- ˛∏dÖç+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++endstream
 endobj
-251 0 obj
+240 0 obj
 <<
-/Ascent 759.7656 /CapHeight 759.7656 /Descent -240.2344 /Flags 4 /FontBBox [ -1020.508 -462.8906 1793.457 1232.422 ] /FontFile2 250 0 R 
+/Ascent 759.7656 /CapHeight 759.7656 /Descent -240.2344 /Flags 4 /FontBBox [ -1020.508 -462.8906 1793.457 1232.422 ] /FontFile2 239 0 R 
   /FontName /AAAAAA+DejaVuSans /ItalicAngle 0 /MissingWidth 600.0977 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-252 0 obj
+241 0 obj
 <<
-/BaseFont /AAAAAA+DejaVuSans /FirstChar 0 /FontDescriptor 251 0 R /LastChar 128 /Name /F9+0 /Subtype /TrueType 
-  /ToUnicode 249 0 R /Type /Font /Widths [ 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 
+/BaseFont /AAAAAA+DejaVuSans /FirstChar 0 /FontDescriptor 240 0 R /LastChar 127 /Name /F9+0 /Subtype /TrueType 
+  /ToUnicode 238 0 R /Type /Font /Widths [ 600.0977 837.8906 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 
   600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 
   600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 600.0977 
   600.0977 600.0977 317.8711 400.8789 459.9609 837.8906 636.2305 950.1953 779.7852 274.9023 
@@ -2360,12 +2281,12 @@ endobj
   685.0586 390.1367 336.9141 390.1367 837.8906 500 500 612.793 634.7656 549.8047 
   634.7656 615.2344 352.0508 634.7656 633.7891 277.832 277.832 579.1016 277.832 974.1211 
   633.7891 611.8164 634.7656 634.7656 411.1328 520.9961 392.0898 633.7891 591.7969 817.8711 
-  591.7969 591.7969 524.9023 636.2305 336.9141 636.2305 837.8906 600.0977 837.8906 ]
+  591.7969 591.7969 524.9023 636.2305 336.9141 636.2305 837.8906 600.0977 ]
 >>
 endobj
-253 0 obj
+242 0 obj
 <<
-/Length 1930
+/Length 1918
 >>
 stream
 /CIDInit /ProcSet findresource begin
@@ -2379,41 +2300,41 @@ begincmap
 /CMapName /AAAAAA+STIXSizeOneSym-Regular def
 /CMapType 2 def
 1 begincodespacerange
-<00> <80>
+<00> <7F>
 endcodespacerange
-129 beginbfchar
+128 beginbfchar
 <00> <0000>
-<01> <0001>
-<02> <0002>
-<03> <0003>
-<04> <0004>
-<05> <0005>
-<06> <0006>
-<07> <0007>
-<08> <0008>
-<09> <0009>
-<0A> <000A>
-<0B> <000B>
-<0C> <000C>
-<0D> <000D>
-<0E> <000E>
-<0F> <000F>
-<10> <0010>
-<11> <0011>
-<12> <0012>
-<13> <0013>
-<14> <0014>
-<15> <0015>
-<16> <0016>
-<17> <0017>
-<18> <0018>
-<19> <0019>
-<1A> <001A>
-<1B> <001B>
-<1C> <001C>
-<1D> <001D>
-<1E> <001E>
-<1F> <001F>
+<01> <221A>
+<02> <0000>
+<03> <0000>
+<04> <0000>
+<05> <0000>
+<06> <0000>
+<07> <0000>
+<08> <0000>
+<09> <0000>
+<0A> <0000>
+<0B> <0000>
+<0C> <0000>
+<0D> <0000>
+<0E> <0000>
+<0F> <0000>
+<10> <0000>
+<11> <0000>
+<12> <0000>
+<13> <0000>
+<14> <0000>
+<15> <0000>
+<16> <0000>
+<17> <0000>
+<18> <0000>
+<19> <0000>
+<1A> <0000>
+<1B> <0000>
+<1C> <0000>
+<1D> <0000>
+<1E> <0000>
+<1F> <0000>
 <20> <0020>
 <21> <0021>
 <22> <0022>
@@ -2510,39 +2431,39 @@ endcodespacerange
 <7D> <007D>
 <7E> <007E>
 <7F> <007F>
-<80> <221A>
 endbfchar
 endcmap
 CMapName currentdict /CMap defineresource pop
 end
 endendstream
 endobj
-254 0 obj
+243 0 obj
 <<
 /Length 11532 /Length1 11532
 >>
 stream
     
- Ä   OS/2ﬂGº7   ¨   `cmap ∂-    glyf:ÔJ¢  $  headÒÉË¨  (   6hhea.ï  `   $hmtxß,  Ñ   0loca§  ¥   maxp S ;  –    nameek†    '¸postˇà   ,Ï     ,ê   ÙÙ   ˙ÙÙ  Ù                c  ÄÃ        STIX @  *ˇÓˇ∑4k†>ê˛                          Å                                                                                                                                                                                                                                               	   
-       ãˇ\~* 
+ Ä   OS/2ﬂGº7   ¨   `cmap Ω#    glyf:ÔJ¢  $  headÒÉË¨  (   6hhea.î  `   $hmtx’ø  Ñ   .locaÿB  ¥   maxp S ;  –    nameek†    '¸postˇà   ,Ï     ,ê   ÙÙ   ˙ÙÙ  Ù                c  ÄÃ        STIX @  *ˇÓˇ∑4k†>ê˛                     
+     Ä                                                                                                                                                                                       	                                                       
+           p˛ŸA   	#.#"'733A˝Œ*Á""§„Ù¯…Ô$ ~˝n    ãˇ\~* 
   &547~pÉÉp¢Üj9ƒ¡=i∆¸˙    Vˇ\I* 
   556VpÉÉp¢j˛«ƒ¡˛√i∆    ˇ\(*   	#(˛:I∆*˚2Œ   ¥ˇ\k*   #3#3k∑∑qq§Œ!˚t    ˇ\(*   #3(I˛<I§Œ   ˇ\ À*   #53#53À∑qq∑§!å!   ˇOËˇÅ   !5!Ë¸Ë±2    rˇ\“* !  &=4&'5>=47“€F??F€@N££à˙®3c
 	d3®˘
 S4yYù<<úY)?n     mˇ\Õ* !  5>54&=475&=4>54'5Õ?F€@N££é€FÕ	d3®˘
-S4zYù<<úY)?n#˙®3c    p˛ŸA   	#.#"'733A˝Œ*Á""§„Ù¯…Ô$ ~˝n        y6˛œ_<ı Ë    »6—ä    »6—ä¸˛ïﬂ             4˛ï  ¸ˇ‡ﬂ                 ˙   ˙  ‘ ã‘ VC  ¥C  Ë  ? r? m! p        0 @ R ` p ~ ∞ ‚       8             @         V       ä       ø       ﬁ       '6       å       ø       ˚       \Ã      	 bÔ      
+S4zYù<<úY)?n#˙®3c        |dˇo_<ı Ë    »6—ä    »6—ä¸˛ïﬂ             4˛ï  ¸ˇ‡ﬂ                 ˙  ! p ˙  ‘ ã‘ VC  ¥C  Ë  ? r m           8 P ` r Ä ê û –       8             @         V       ä       ø       ﬁ       '6       å       ø       ˚       \Ã      	 bÔ      
 ’˛              [      „!A       *&{  	      	  °  	  Œ  	  NÊ  	  ,^  	  £  	  ,Õ  	  ∏  	 	 ƒ)  	 
 	™R  	  0‘  	  :  	 	∆y  	  T&% C o p y r i g h t   ( c )   2 0 0 1 - 2 0 1 0   b y   t h e   S T I   P u b   C o m p a n i e s ,   c o n s i s t i n g   o f   t h e   A m e r i c a n   C h e m i c a l   S o c i e t y ,   t h e   A m e r i c a n   I n s t i t u t e   o f   P h y s i c s ,   t h e   A m e r i c a n   M a t h e m a t i c a l   S o c i e t y ,   t h e   A m e r i c a n   P h y s i c a l   S o c i e t y ,   E l s e v i e r ,   I n c . ,   a n d   T h e   I n s t i t u t e   o f   E l e c t r i c a l   a n d   E l e c t r o n i c   E n g i n e e r s ,   I n c .   P o r t i o n s   c o p y r i g h t   ( c )   1 9 9 8 - 2 0 0 3   b y   M i c r o P r e s s ,   I n c .   P o r t i o n s   c o p y r i g h t   ( c )   1 9 9 0   b y   E l s e v i e r ,   I n c .   A l l   r i g h t s   r e s e r v e d .  Copyright (c) 2001-2010 by the STI Pub Companies, consisting of the American Chemical Society, the American Institute of Physics, the American Mathematical Society, the American Physical Society, Elsevier, Inc., and The Institute of Electrical and Electronic Engineers, Inc. Portions copyright (c) 1998-2003 by MicroPress, Inc. Portions copyright (c) 1990 by Elsevier, Inc. All rights reserved.  S T I X S i z e O n e S y m  STIXSizeOneSym  R e g u l a r  Regular  F o n t M a s t e r : S T I X S i z e O n e S y m - R e g u l a r : 1 . 0 . 0  FontMaster:STIXSizeOneSym-Regular:1.0.0  S T I X S i z e O n e S y m - R e g u l a r  STIXSizeOneSym-Regular  V e r s i o n   1 . 0 . 0  Version 1.0.0  S T I X S i z e O n e S y m - R e g u l a r  STIXSizeOneSym-Regular  S T I X   F o n t s ( T M )   i s   a   t r a d e m a r k   o f   T h e   I n s t i t u t e   o f   E l e c t r i c a l   a n d   E l e c t r o n i c s   E n g i n e e r s ,   I n c .  STIX Fonts(TM) is a trademark of The Institute of Electrical and Electronics Engineers, Inc.  M i c r o P r e s s   I n c . ,   w i t h   f i n a l   a d d i t i o n s   a n d   c o r r e c t i o n s   p r o v i d e d   b y   C o e n   H o f f m a n ,   E l s e v i e r   ( r e t i r e d )  MicroPress Inc., with final additions and corrections provided by Coen Hoffman, Elsevier (retired)  A r i e   d e   R u i t e r ,   w h o   i n   1 9 9 5   w a s   H e a d   o f   I n f o r m a t i o n   T e c h n o l o g y   D e v e l o p m e n t   a t   E l s e v i e r   S c i e n c e ,   m a d e   a   p r o p o s a l   t o   t h e   S T I   P u b   g r o u p ,   a n   i n f o r m a l   g r o u p   o f   p u b l i s h e r s   c o n s i s t i n g   o f   r e p r e s e n t a t i v e s   f r o m   t h e   A m e r i c a n   C h e m i c a l   S o c i e t y   ( A C S ) ,   A m e r i c a n   I n s t i t u t e   o f   P h y s i c s   ( A I P ) ,   A m e r i c a n   M a t h e m a t i c a l   S o c i e t y   ( A M S ) ,   A m e r i c a n   P h y s i c a l   S o c i e t y   ( A P S ) ,   E l s e v i e r ,   a n d   I n s t i t u t e   o f   E l e c t r i c a l   a n d   E l e c t r o n i c s   E n g i n e e r s   ( I E E E ) .   D e   R u i t e r   e n c o u r a g e d   t h e   m e m b e r s   t o   c o n s i d e r   d e v e l o p m e n t   o f   a   s e r i e s   o f   W e b   f o n t s ,   w h i c h   h e   p r o p o s e d   s h o u l d   b e   c a l l e d   t h e   S c i e n t i f i c   a n d   T e c h n i c a l   I n f o r m a t i o n   e X c h a n g e ,   o r   S T I X ,   F o n t s .   A l l   S T I   P u b   m e m b e r   o r g a n i z a t i o n s   e n t h u s i a s t i c a l l y   e n d o r s e d   t h i s   p r o p o s a l ,   a n d   t h e   S T I   P u b   g r o u p   a g r e e d   t o   e m b a r k   o n   w h a t   h a s   b e c o m e   a   t w e l v e - y e a r   p r o j e c t .   T h e   g o a l   o f   t h e   p r o j e c t   w a s   t o   i d e n t i f y   a l l   a l p h a b e t i c ,   s y m b o l i c ,   a n d   o t h e r   s p e c i a l   c h a r a c t e r s   u s e d   i n   a n y   f a c e t   o f   s c i e n t i f i c   p u b l i s h i n g   a n d   t o   c r e a t e   a   s e t   o f   U n i c o d e - b a s e d   f o n t s   t h a t   w o u l d   b e   d i s t r i b u t e d   f r e e   t o   e v e r y   s c i e n t i s t ,   s t u d e n t ,   a n d   o t h e r   i n t e r e s t e d   p a r t y   w o r l d w i d e .   T h e   f o n t s   w o u l d   b e   c o n s i s t e n t   w i t h   t h e   e m e r g i n g   U n i c o d e   s t a n d a r d ,   a n d   w o u l d   p e r m i t   u n i v e r s a l   r e p r e s e n t a t i o n   o f   e v e r y   c h a r a c t e r .   W i t h   t h e   r e l e a s e   o f   t h e   S T I X   f o n t s ,   d e   R u i t e r ' s   v i s i o n   h a s   b e e n   r e a l i z e d .  Arie de Ruiter, who in 1995 was Head of Information Technology Development at Elsevier Science, made a proposal to the STI Pub group, an informal group of publishers consisting of representatives from the American Chemical Society (ACS), American Institute of Physics (AIP), American Mathematical Society (AMS), American Physical Society (APS), Elsevier, and Institute of Electrical and Electronics Engineers (IEEE). De Ruiter encouraged the members to consider development of a series of Web fonts, which he proposed should be called the Scientific and Technical Information eXchange, or STIX, Fonts. All STI Pub member organizations enthusiastically endorsed this proposal, and the STI Pub group agreed to embark on what has become a twelve-year project. The goal of the project was to identify all alphabetic, symbolic, and other special characters used in any facet of scientific publishing and to create a set of Unicode-based fonts that would be distributed free to every scientist, student, and other interested party worldwide. The fonts would be consistent with the emerging Unicode standard, and would permit universal representation of every character. With the release of the STIX fonts, de Ruiter's vision has been realized.  h t t p : / / w w w . s t i x f o n t s . o r g  http://www.stixfonts.org  h t t p : / / w w w . m i c r o p r e s s - i n c . c o m  http://www.micropress-inc.com  A s   a   c o n d i t i o n   f o r   r e c e i v i n g   t h e s e   f o n t s   a t   n o   c h a r g e ,   e a c h   p e r s o n   d o w n l o a d i n g   t h e   f o n t s   m u s t   a g r e e   t o   s o m e   s i m p l e   l i c e n s e   t e r m s .   T h e   l i c e n s e   i s   b a s e d   o n   t h e   S I L   O p e n   F o n t   L i c e n s e   < h t t p : / / s c r i p t s . s i l . o r g / c m s / s c r i p t s / p a g e . p h p ? s i t e _ i d = n r s i & i d = O F L > .   T h e   S I L   L i c e n s e   i s   a   f r e e   a n d   o p e n   s o u r c e   l i c e n s e   s p e c i f i c a l l y   d e s i g n e d   f o r   f o n t s   a n d   r e l a t e d   s o f t w a r e .   T h e   b a s i c   t e r m s   a r e   t h a t   t h e   r e c i p i e n t   w i l l   n o t   r e m o v e   t h e   c o p y r i g h t   a n d   t r a d e m a r k   s t a t e m e n t s   f r o m   t h e   f o n t s   a n d   t h a t ,   i f   t h e   p e r s o n   d e c i d e s   t o   c r e a t e   a   d e r i v a t i v e   w o r k   b a s e d   o n   t h e   S T I X   F o n t s   b u t   i n c o r p o r a t i n g   s o m e   c h a n g e s   o r   e n h a n c e m e n t s ,   t h e   d e r i v a t i v e   w o r k   ( " M o d i f i e d   V e r s i o n " )   w i l l   c a r r y   a   d i f f e r e n t   n a m e .   T h e   c o p y r i g h t   a n d   t r a d e m a r k   r e s t r i c t i o n s   a r e   p a r t   o f   t h e   a g r e e m e n t   b e t w e e n   t h e   S T I   P u b   c o m p a n i e s   a n d   t h e   t y p e f a c e   d e s i g n e r .   T h e   " r e n a m i n g "   r e s t r i c t i o n   r e s u l t s   f r o m   t h e   d e s i r e   o f   t h e   S T I   P u b   c o m p a n i e s   t o   a s s u r e   t h a t   t h e   S T I X   F o n t s   w i l l   c o n t i n u e   t o   f u n c t i o n   i n   a   p r e d i c t a b l e   f a s h i o n   f o r   a l l   t h a t   u s e   t h e m .   N o   c o p y   o f   o n e   o r   m o r e   o f   t h e   i n d i v i d u a l   F o n t   t y p e f a c e s   t h a t   f o r m   t h e   S T I X   F o n t s ( T M )   s e t   m a y   b e   s o l d   b y   i t s e l f ,   b u t   o t h e r   t h a n   t h i s   o n e   r e s t r i c t i o n ,   l i c e n s e e s   a r e   f r e e   t o   s e l l   t h e   f o n t s   e i t h e r   s e p a r a t e l y   o r   a s   p a r t   o f   a   p a c k a g e   t h a t   c o m b i n e s   o t h e r   s o f t w a r e   o r   f o n t s   w i t h   t h i s   f o n t   s e t .  As a condition for receiving these fonts at no charge, each person downloading the fonts must agree to some simple license terms. The license is based on the SIL Open Font License <http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL>. The SIL License is a free and open source license specifically designed for fonts and related software. The basic terms are that the recipient will not remove the copyright and trademark statements from the fonts and that, if the person decides to create a derivative work based on the STIX Fonts but incorporating some changes or enhancements, the derivative work ("Modified Version") will carry a different name. The copyright and trademark restrictions are part of the agreement between the STI Pub companies and the typeface designer. The "renaming" restriction results from the desire of the STI Pub companies to assure that the STIX Fonts will continue to function in a predictable fashion for all that use them. No copy of one or more of the individual Font typefaces that form the STIX Fonts(TM) set may be sold by itself, but other than this one restriction, licensees are free to sell the fonts either separately or as part of a package that combines other software or fonts with this font set.  h t t p : / / w w w . s t i x f o n t s . o r g / u s e r _ l i c e n s e . h t m l  http://www.stixfonts.org/user_license.html        ˇÖ                     endstream
 endobj
-255 0 obj
+244 0 obj
 <<
-/Ascent 750 /CapHeight 0 /Descent -250 /Flags 4 /FontBBox [ -1000 -363 1503 1566 ] /FontFile2 254 0 R 
+/Ascent 750 /CapHeight 0 /Descent -250 /Flags 4 /FontBBox [ -1000 -363 1503 1566 ] /FontFile2 243 0 R 
   /FontName /AAAAAA+STIXSizeOneSym-Regular /ItalicAngle 0 /MissingWidth 250 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-256 0 obj
+245 0 obj
 <<
-/BaseFont /AAAAAA+STIXSizeOneSym-Regular /FirstChar 0 /FontDescriptor 255 0 R /LastChar 128 /Name /F10+0 /Subtype /TrueType 
-  /ToUnicode 253 0 R /Type /Font /Widths [ 250 250 250 250 250 250 250 250 250 250 
+/BaseFont /AAAAAA+STIXSizeOneSym-Regular /FirstChar 0 /FontDescriptor 244 0 R /LastChar 127 /Name /F10+0 /Subtype /TrueType 
+  /ToUnicode 242 0 R /Type /Font /Widths [ 250 1057 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
@@ -2554,408 +2475,395 @@ endobj
   250 383 579 383 250 1000 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
-  250 250 250 575 250 575 250 250 1057 ]
+  250 250 250 575 250 575 250 250 ]
+>>
+endobj
+246 0 obj
+<<
+/Outlines 248 0 R /PageLabels 368 0 R /PageMode /UseNone /Pages 318 0 R /Type /Catalog
+>>
+endobj
+247 0 obj
+<<
+/Author () /CreationDate (D:20241224161726+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20241224161726+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (How to use rst2pdf) /Trapped /False
+>>
+endobj
+248 0 obj
+<<
+/Count 85 /First 249 0 R /Last 317 0 R /Type /Outlines
+>>
+endobj
+249 0 obj
+<<
+/Count 1 /Dest [ 152 0 R /XYZ 57.02362 747.0236 0 ] /First 250 0 R /Last 250 0 R /Next 251 0 R /Parent 248 0 R 
+  /Title (\376\377\0001\000\240\000\240\000\240\000I\000n\000t\000r\000o\000d\000u\000c\000t\000i\000o\000n)
+>>
+endobj
+250 0 obj
+<<
+/Dest [ 152 0 R /XYZ 57.02362 570.8236 0 ] /Parent 249 0 R /Title (\376\377\0001\000.\0001\000\240\000\240\000\240\000R\000e\000l\000a\000t\000e\000d\000 \000R\000e\000a\000d\000i\000n\000g)
+>>
+endobj
+251 0 obj
+<<
+/Count 6 /Dest [ 154 0 R /XYZ 57.02362 747.0236 0 ] /First 252 0 R /Last 257 0 R /Next 258 0 R /Parent 248 0 R 
+  /Prev 249 0 R /Title (\376\377\0002\000\240\000\240\000\240\000C\000o\000m\000m\000a\000n\000d\000 \000l\000i\000n\000e\000 \000o\000p\000t\000i\000o\000n\000s)
+>>
+endobj
+252 0 obj
+<<
+/Dest [ 154 0 R /XYZ 57.02362 696.0236 0 ] /Next 253 0 R /Parent 251 0 R /Title (\376\377\0002\000.\0001\000\240\000\240\000\240\000G\000e\000n\000e\000r\000a\000l\000 \000O\000p\000t\000i\000o\000n\000s)
+>>
+endobj
+253 0 obj
+<<
+/Dest [ 154 0 R /XYZ 57.02362 546.0236 0 ] /Next 254 0 R /Parent 251 0 R /Prev 252 0 R /Title (\376\377\0002\000.\0002\000\240\000\240\000\240\000F\000i\000l\000e\000 \000a\000n\000d\000 \000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n)
+>>
+endobj
+254 0 obj
+<<
+/Dest [ 154 0 R /XYZ 57.02362 432.0236 0 ] /Next 255 0 R /Parent 251 0 R /Prev 253 0 R /Title (\376\377\0002\000.\0003\000\240\000\240\000\240\000S\000t\000y\000l\000i\000n\000g\000 \000O\000p\000t\000i\000o\000n\000s)
+>>
+endobj
+255 0 obj
+<<
+/Dest [ 154 0 R /XYZ 57.02362 264.0236 0 ] /Next 256 0 R /Parent 251 0 R /Prev 254 0 R /Title (\376\377\0002\000.\0004\000\240\000\240\000\240\000P\000D\000F\000 \000O\000p\000t\000i\000o\000n\000s)
+>>
+endobj
+256 0 obj
+<<
+/Dest [ 155 0 R /XYZ 57.02362 747.0236 0 ] /Next 257 0 R /Parent 251 0 R /Prev 255 0 R /Title (\376\377\0002\000.\0005\000\240\000\240\000\240\000F\000o\000r\000m\000a\000t\000t\000i\000n\000g\000 \000O\000p\000t\000i\000o\000n\000s)
 >>
 endobj
 257 0 obj
 <<
-/Outlines 259 0 R /PageLabels 384 0 R /PageMode /UseNone /Pages 331 0 R /Type /Catalog
+/Dest [ 155 0 R /XYZ 57.02362 459.0236 0 ] /Parent 251 0 R /Prev 256 0 R /Title (\376\377\0002\000.\0006\000\240\000\240\000\240\000M\000i\000s\000c\000e\000l\000l\000a\000n\000e\000o\000u\000s\000 \000O\000p\000t\000i\000o\000n\000s)
 >>
 endobj
 258 0 obj
 <<
-/Author () /CreationDate (D:20240605203543+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20240605203543+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
-  /Subject (\(unspecified\)) /Title (How to use rst2pdf) /Trapped /False
+/Count 2 /Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /First 259 0 R /Last 260 0 R /Next 261 0 R /Parent 248 0 R 
+  /Prev 251 0 R /Title (\376\377\0003\000\240\000\240\000\240\000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n\000 \000F\000i\000l\000e)
 >>
 endobj
 259 0 obj
 <<
-/Count 89 /First 260 0 R /Last 330 0 R /Type /Outlines
+/Dest [ 157 0 R /XYZ 57.02362 636.0236 0 ] /Next 260 0 R /Parent 258 0 R /Title (\376\377\0003\000.\0001\000\240\000\240\000\240\000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n\000 \000O\000p\000t\000i\000o\000n\000s)
 >>
 endobj
 260 0 obj
 <<
-/Count 1 /Dest [ 156 0 R /XYZ 57.02362 747.0236 0 ] /First 261 0 R /Last 261 0 R /Next 262 0 R /Parent 259 0 R 
-  /Title (\376\377\0001\000\240\000\240\000\240\000I\000n\000t\000r\000o\000d\000u\000c\000t\000i\000o\000n)
+/Dest [ 160 0 R /XYZ 57.02362 447.0236 0 ] /Parent 258 0 R /Prev 259 0 R /Title (\376\377\0003\000.\0002\000\240\000\240\000\240\000E\000x\000a\000m\000p\000l\000e\000 \000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n\000 \000F\000i\000l\000e)
 >>
 endobj
 261 0 obj
 <<
-/Dest [ 156 0 R /XYZ 57.02362 570.8236 0 ] /Parent 260 0 R /Title (\376\377\0001\000.\0001\000\240\000\240\000\240\000R\000e\000l\000a\000t\000e\000d\000 \000R\000e\000a\000d\000i\000n\000g)
+/Dest [ 161 0 R /XYZ 57.02362 747.0236 0 ] /Next 262 0 R /Parent 248 0 R /Prev 258 0 R /Title (\376\377\0004\000\240\000\240\000\240\000P\000i\000p\000e\000 \000u\000s\000a\000g\000e)
 >>
 endobj
 262 0 obj
 <<
-/Dest [ 157 0 R /XYZ 57.02362 747.0236 0 ] /Next 263 0 R /Parent 259 0 R /Prev 260 0 R /Title (\376\377\0002\000\240\000\240\000\240\000C\000o\000m\000m\000a\000n\000d\000 \000l\000i\000n\000e\000 \000o\000p\000t\000i\000o\000n\000s)
+/Count 3 /Dest [ 165 0 R /XYZ 57.02362 747.0236 0 ] /First 263 0 R /Last 265 0 R /Next 266 0 R /Parent 248 0 R 
+  /Prev 261 0 R /Title (\376\377\0005\000\240\000\240\000\240\000I\000m\000a\000g\000e\000s)
 >>
 endobj
 263 0 obj
 <<
-/Dest [ 162 0 R /XYZ 57.02362 747.0236 0 ] /Next 264 0 R /Parent 259 0 R /Prev 262 0 R /Title (\376\377\0003\000\240\000\240\000\240\000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n\000 \000F\000i\000l\000e)
+/Dest [ 165 0 R /XYZ 57.02362 714.0236 0 ] /Next 264 0 R /Parent 262 0 R /Title (\376\377\0005\000.\0001\000\240\000\240\000\240\000I\000n\000l\000i\000n\000e)
 >>
 endobj
 264 0 obj
 <<
-/Dest [ 164 0 R /XYZ 57.02362 747.0236 0 ] /Next 265 0 R /Parent 259 0 R /Prev 263 0 R /Title (\376\377\0004\000\240\000\240\000\240\000P\000i\000p\000e\000 \000u\000s\000a\000g\000e)
+/Dest [ 165 0 R /XYZ 57.02362 588.8236 0 ] /Next 265 0 R /Parent 262 0 R /Prev 263 0 R /Title (\376\377\0005\000.\0002\000\240\000\240\000\240\000S\000u\000p\000p\000o\000r\000t\000e\000d\000 \000I\000m\000a\000g\000e\000 \000T\000y\000p\000e\000s)
 >>
 endobj
 265 0 obj
 <<
-/Count 3 /Dest [ 168 0 R /XYZ 57.02362 747.0236 0 ] /First 266 0 R /Last 268 0 R /Next 269 0 R /Parent 259 0 R 
-  /Prev 264 0 R /Title (\376\377\0005\000\240\000\240\000\240\000I\000m\000a\000g\000e\000s)
+/Dest [ 165 0 R /XYZ 57.02362 313.8236 0 ] /Parent 262 0 R /Prev 264 0 R /Title (\376\377\0005\000.\0003\000\240\000\240\000\240\000I\000m\000a\000g\000e\000 \000S\000i\000z\000e)
 >>
 endobj
 266 0 obj
 <<
-/Dest [ 168 0 R /XYZ 57.02362 714.0236 0 ] /Next 267 0 R /Parent 265 0 R /Title (\376\377\0005\000.\0001\000\240\000\240\000\240\000I\000n\000l\000i\000n\000e)
+/Count 3 /Dest [ 170 0 R /XYZ 57.02362 747.0236 0 ] /First 267 0 R /Last 269 0 R /Next 270 0 R /Parent 248 0 R 
+  /Prev 262 0 R /Title (\376\377\0006\000\240\000\240\000\240\000S\000t\000y\000l\000i\000n\000g\000 \000R\000e\000S\000t\000r\000u\000c\000t\000u\000r\000e\000d\000T\000e\000x\000t)
 >>
 endobj
 267 0 obj
 <<
-/Dest [ 168 0 R /XYZ 57.02362 588.8236 0 ] /Next 268 0 R /Parent 265 0 R /Prev 266 0 R /Title (\376\377\0005\000.\0002\000\240\000\240\000\240\000S\000u\000p\000p\000o\000r\000t\000e\000d\000 \000I\000m\000a\000g\000e\000 \000T\000y\000p\000e\000s)
+/Dest [ 170 0 R /XYZ 57.02362 642.0236 0 ] /Next 268 0 R /Parent 266 0 R /Title (\376\377\0006\000.\0001\000\240\000\240\000\240\000A\000p\000p\000l\000y\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s)
 >>
 endobj
 268 0 obj
 <<
-/Dest [ 168 0 R /XYZ 57.02362 313.8236 0 ] /Parent 265 0 R /Prev 267 0 R /Title (\376\377\0005\000.\0003\000\240\000\240\000\240\000I\000m\000a\000g\000e\000 \000S\000i\000z\000e)
+/Dest [ 170 0 R /XYZ 57.02362 152.4236 0 ] /Next 269 0 R /Parent 266 0 R /Prev 267 0 R /Title (\376\377\0006\000.\0002\000\240\000\240\000\240\000H\000e\000a\000d\000e\000r\000s\000 \000a\000n\000d\000 \000F\000o\000o\000t\000e\000r\000s)
 >>
 endobj
 269 0 obj
 <<
-/Count 3 /Dest [ 173 0 R /XYZ 57.02362 747.0236 0 ] /First 270 0 R /Last 272 0 R /Next 273 0 R /Parent 259 0 R 
-  /Prev 265 0 R /Title (\376\377\0006\000\240\000\240\000\240\000S\000t\000y\000l\000i\000n\000g\000 \000R\000e\000S\000t\000r\000u\000c\000t\000u\000r\000e\000d\000T\000e\000x\000t)
+/Dest [ 175 0 R /XYZ 57.02362 426.8236 0 ] /Parent 266 0 R /Prev 268 0 R /Title (\376\377\0006\000.\0003\000\240\000\240\000\240\000F\000o\000o\000t\000n\000o\000t\000e\000s)
 >>
 endobj
 270 0 obj
 <<
-/Dest [ 173 0 R /XYZ 57.02362 642.0236 0 ] /Next 271 0 R /Parent 269 0 R /Title (\376\377\0006\000.\0001\000\240\000\240\000\240\000A\000p\000p\000l\000y\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s)
+/Count 7 /Dest [ 176 0 R /XYZ 57.02362 747.0236 0 ] /First 271 0 R /Last 275 0 R /Next 278 0 R /Parent 248 0 R 
+  /Prev 266 0 R /Title (\376\377\0007\000\240\000\240\000\240\000C\000u\000s\000t\000o\000m\000i\000z\000i\000n\000g\000 \000P\000D\000F\000 \000O\000u\000t\000p\000u\000t)
 >>
 endobj
 271 0 obj
 <<
-/Dest [ 173 0 R /XYZ 57.02362 152.4236 0 ] /Next 272 0 R /Parent 269 0 R /Prev 270 0 R /Title (\376\377\0006\000.\0002\000\240\000\240\000\240\000H\000e\000a\000d\000e\000r\000s\000 \000a\000n\000d\000 \000F\000o\000o\000t\000e\000r\000s)
+/Dest [ 176 0 R /XYZ 57.02362 594.0236 0 ] /Next 272 0 R /Parent 270 0 R /Title (\376\377\0007\000.\0001\000\240\000\240\000\240\000U\000s\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000s)
 >>
 endobj
 272 0 obj
 <<
-/Dest [ 179 0 R /XYZ 57.02362 426.8236 0 ] /Parent 269 0 R /Prev 271 0 R /Title (\376\377\0006\000.\0003\000\240\000\240\000\240\000F\000o\000o\000t\000n\000o\000t\000e\000s)
+/Dest [ 176 0 R /XYZ 57.02362 307.6236 0 ] /Next 273 0 R /Parent 270 0 R /Prev 271 0 R /Title (\376\377\0007\000.\0002\000\240\000\240\000\240\000I\000n\000c\000l\000u\000d\000e\000d\000 \000S\000t\000y\000l\000e\000S\000h\000e\000e\000t\000s)
 >>
 endobj
 273 0 obj
 <<
-/Count 7 /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /First 274 0 R /Last 278 0 R /Next 281 0 R /Parent 259 0 R 
-  /Prev 269 0 R /Title (\376\377\0007\000\240\000\240\000\240\000C\000u\000s\000t\000o\000m\000i\000z\000i\000n\000g\000 \000P\000D\000F\000 \000O\000u\000t\000p\000u\000t)
+/Dest [ 178 0 R /XYZ 57.02362 558.8236 0 ] /Next 274 0 R /Parent 270 0 R /Prev 272 0 R /Title (\376\377\0007\000.\0003\000\240\000\240\000\240\000D\000e\000f\000a\000u\000l\000t\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t)
 >>
 endobj
 274 0 obj
 <<
-/Dest [ 180 0 R /XYZ 57.02362 594.0236 0 ] /Next 275 0 R /Parent 273 0 R /Title (\376\377\0007\000.\0001\000\240\000\240\000\240\000U\000s\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000s)
+/Dest [ 178 0 R /XYZ 57.02362 445.6236 0 ] /Next 275 0 R /Parent 270 0 R /Prev 273 0 R /Title (\376\377\0007\000.\0004\000\240\000\240\000\240\000M\000i\000g\000r\000a\000t\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000 \000F\000o\000r\000m\000a\000t)
 >>
 endobj
 275 0 obj
 <<
-/Dest [ 180 0 R /XYZ 57.02362 307.6236 0 ] /Next 276 0 R /Parent 273 0 R /Prev 274 0 R /Title (\376\377\0007\000.\0002\000\240\000\240\000\240\000I\000n\000c\000l\000u\000d\000e\000d\000 \000S\000t\000y\000l\000e\000S\000h\000e\000e\000t\000s)
+/Count 2 /Dest [ 178 0 R /XYZ 57.02362 272.8387 0 ] /First 276 0 R /Last 277 0 R /Parent 270 0 R /Prev 274 0 R 
+  /Title (\376\377\0007\000.\0005\000\240\000\240\000\240\000M\000i\000g\000r\000a\000t\000i\000n\000g\000 \000t\000o\000 \000t\000h\000e\000 \000N\000e\000w\000 \000D\000e\000f\000a\000u\000l\000t\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t)
 >>
 endobj
 276 0 obj
 <<
-/Dest [ 182 0 R /XYZ 57.02362 558.8236 0 ] /Next 277 0 R /Parent 273 0 R /Prev 275 0 R /Title (\376\377\0007\000.\0003\000\240\000\240\000\240\000D\000e\000f\000a\000u\000l\000t\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t)
+/Dest [ 178 0 R /XYZ 57.02362 125.6387 0 ] /Next 277 0 R /Parent 275 0 R /Title (\376\377\0007\000.\0005\000.\0001\000\240\000\240\000\240\000U\000p\000d\000a\000t\000e\000d\000 \000F\000o\000n\000t\000 \000A\000l\000i\000a\000s\000 \000N\000a\000m\000e\000s)
 >>
 endobj
 277 0 obj
 <<
-/Dest [ 182 0 R /XYZ 57.02362 445.6236 0 ] /Next 278 0 R /Parent 273 0 R /Prev 276 0 R /Title (\376\377\0007\000.\0004\000\240\000\240\000\240\000M\000i\000g\000r\000a\000t\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000 \000F\000o\000r\000m\000a\000t)
+/Dest [ 179 0 R /XYZ 57.02362 465.0236 0 ] /Parent 275 0 R /Prev 276 0 R /Title (\376\377\0007\000.\0005\000.\0002\000\240\000\240\000\240\000U\000p\000d\000a\000t\000e\000d\000 \000P\000a\000t\000e\000 \000T\000e\000m\000p\000l\000a\000t\000e\000 \000N\000a\000m\000e\000s)
 >>
 endobj
 278 0 obj
 <<
-/Count 2 /Dest [ 182 0 R /XYZ 57.02362 272.8387 0 ] /First 279 0 R /Last 280 0 R /Parent 273 0 R /Prev 277 0 R 
-  /Title (\376\377\0007\000.\0005\000\240\000\240\000\240\000M\000i\000g\000r\000a\000t\000i\000n\000g\000 \000t\000o\000 \000t\000h\000e\000 \000N\000e\000w\000 \000D\000e\000f\000a\000u\000l\000t\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t)
+/Count 10 /Dest [ 180 0 R /XYZ 57.02362 747.0236 0 ] /First 279 0 R /Last 288 0 R /Next 289 0 R /Parent 248 0 R 
+  /Prev 270 0 R /Title (\376\377\0008\000\240\000\240\000\240\000C\000r\000e\000a\000t\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000s)
 >>
 endobj
 279 0 obj
 <<
-/Dest [ 182 0 R /XYZ 57.02362 125.6387 0 ] /Next 280 0 R /Parent 278 0 R /Title (\376\377\0007\000.\0005\000.\0001\000\240\000\240\000\240\000U\000p\000d\000a\000t\000e\000d\000 \000F\000o\000n\000t\000 \000A\000l\000i\000a\000s\000 \000N\000a\000m\000e\000s)
+/Dest [ 180 0 R /XYZ 57.02362 536.8236 0 ] /Next 280 0 R /Parent 278 0 R /Title (\376\377\0008\000.\0001\000\240\000\240\000\240\000S\000t\000y\000l\000e\000s\000 \000i\000n\000 \000D\000e\000t\000a\000i\000l)
 >>
 endobj
 280 0 obj
 <<
-/Dest [ 183 0 R /XYZ 57.02362 465.0236 0 ] /Parent 278 0 R /Prev 279 0 R /Title (\376\377\0007\000.\0005\000.\0002\000\240\000\240\000\240\000U\000p\000d\000a\000t\000e\000d\000 \000P\000a\000t\000e\000 \000T\000e\000m\000p\000l\000a\000t\000e\000 \000N\000a\000m\000e\000s)
+/Count 2 /Dest [ 183 0 R /XYZ 57.02362 747.0236 0 ] /First 281 0 R /Last 282 0 R /Next 283 0 R /Parent 278 0 R 
+  /Prev 279 0 R /Title (\376\377\0008\000.\0002\000\240\000\240\000\240\000S\000t\000y\000l\000e\000 \000E\000l\000e\000m\000e\000n\000t\000s)
 >>
 endobj
 281 0 obj
 <<
-/Count 10 /Dest [ 184 0 R /XYZ 57.02362 747.0236 0 ] /First 282 0 R /Last 291 0 R /Next 292 0 R /Parent 259 0 R 
-  /Prev 273 0 R /Title (\376\377\0008\000\240\000\240\000\240\000C\000r\000e\000a\000t\000i\000n\000g\000 \000S\000t\000y\000l\000e\000s\000h\000e\000e\000t\000s)
+/Dest [ 187 0 R /XYZ 57.02362 363.4236 0 ] /Next 282 0 R /Parent 280 0 R /Title (\376\377\0008\000.\0002\000.\0001\000\240\000\240\000\240\000I\000n\000l\000i\000n\000e\000 \000S\000t\000y\000l\000e\000s)
 >>
 endobj
 282 0 obj
 <<
-/Dest [ 184 0 R /XYZ 57.02362 536.8236 0 ] /Next 283 0 R /Parent 281 0 R /Title (\376\377\0008\000.\0001\000\240\000\240\000\240\000S\000t\000y\000l\000e\000s\000 \000i\000n\000 \000D\000e\000t\000a\000i\000l)
+/Dest [ 187 0 R /XYZ 57.02362 246.4236 0 ] /Parent 280 0 R /Prev 281 0 R /Title (\376\377\0008\000.\0002\000.\0002\000\240\000\240\000\240\000L\000i\000s\000t\000s)
 >>
 endobj
 283 0 obj
 <<
-/Count 2 /Dest [ 187 0 R /XYZ 57.02362 747.0236 0 ] /First 284 0 R /Last 285 0 R /Next 286 0 R /Parent 281 0 R 
-  /Prev 282 0 R /Title (\376\377\0008\000.\0002\000\240\000\240\000\240\000S\000t\000y\000l\000e\000 \000E\000l\000e\000m\000e\000n\000t\000s)
+/Count 2 /Dest [ 188 0 R /XYZ 57.02362 462.6236 0 ] /First 284 0 R /Last 285 0 R /Next 286 0 R /Parent 278 0 R 
+  /Prev 280 0 R /Title (\376\377\0008\000.\0003\000\240\000\240\000\240\000P\000a\000g\000e\000 \000L\000a\000y\000o\000u\000t)
 >>
 endobj
 284 0 obj
 <<
-/Dest [ 191 0 R /XYZ 57.02362 363.4236 0 ] /Next 285 0 R /Parent 283 0 R /Title (\376\377\0008\000.\0002\000.\0001\000\240\000\240\000\240\000I\000n\000l\000i\000n\000e\000 \000S\000t\000y\000l\000e\000s)
+/Dest [ 188 0 R /XYZ 57.02362 402.6236 0 ] /Next 285 0 R /Parent 283 0 R /Title (\376\377\0008\000.\0003\000.\0001\000\240\000\240\000\240\000P\000a\000g\000e\000 \000S\000e\000t\000u\000p)
 >>
 endobj
 285 0 obj
 <<
-/Dest [ 191 0 R /XYZ 57.02362 246.4236 0 ] /Parent 283 0 R /Prev 284 0 R /Title (\376\377\0008\000.\0002\000.\0002\000\240\000\240\000\240\000L\000i\000s\000t\000s)
+/Dest [ 189 0 R /XYZ 57.02362 677.8236 0 ] /Parent 283 0 R /Prev 284 0 R /Title (\376\377\0008\000.\0003\000.\0002\000\240\000\240\000\240\000P\000a\000g\000e\000 \000T\000e\000m\000p\000l\000a\000t\000e\000s)
 >>
 endobj
 286 0 obj
 <<
-/Count 2 /Dest [ 192 0 R /XYZ 57.02362 462.6236 0 ] /First 287 0 R /Last 288 0 R /Next 289 0 R /Parent 281 0 R 
-  /Prev 283 0 R /Title (\376\377\0008\000.\0003\000\240\000\240\000\240\000P\000a\000g\000e\000 \000L\000a\000y\000o\000u\000t)
+/Dest [ 191 0 R /XYZ 57.02362 473.8236 0 ] /Next 287 0 R /Parent 278 0 R /Prev 283 0 R /Title (\376\377\0008\000.\0004\000\240\000\240\000\240\000F\000o\000n\000t\000 \000A\000l\000i\000a\000s)
 >>
 endobj
 287 0 obj
 <<
-/Dest [ 192 0 R /XYZ 57.02362 402.6236 0 ] /Next 288 0 R /Parent 286 0 R /Title (\376\377\0008\000.\0003\000.\0001\000\240\000\240\000\240\000P\000a\000g\000e\000 \000S\000e\000t\000u\000p)
+/Dest [ 191 0 R /XYZ 57.02362 270.6236 0 ] /Next 288 0 R /Parent 278 0 R /Prev 286 0 R /Title (\376\377\0008\000.\0005\000\240\000\240\000\240\000W\000i\000d\000o\000w\000s\000 \000a\000n\000d\000 \000O\000r\000p\000h\000a\000n\000s)
 >>
 endobj
 288 0 obj
 <<
-/Dest [ 193 0 R /XYZ 57.02362 677.8236 0 ] /Parent 286 0 R /Prev 287 0 R /Title (\376\377\0008\000.\0003\000.\0002\000\240\000\240\000\240\000P\000a\000g\000e\000 \000T\000e\000m\000p\000l\000a\000t\000e\000s)
+/Dest [ 192 0 R /XYZ 57.02362 581.8236 0 ] /Parent 278 0 R /Prev 287 0 R /Title (\376\377\0008\000.\0006\000\240\000\240\000\240\000T\000a\000b\000l\000e\000 \000S\000t\000y\000l\000e\000s)
 >>
 endobj
 289 0 obj
 <<
-/Dest [ 195 0 R /XYZ 57.02362 473.8236 0 ] /Next 290 0 R /Parent 281 0 R /Prev 286 0 R /Title (\376\377\0008\000.\0004\000\240\000\240\000\240\000F\000o\000n\000t\000 \000A\000l\000i\000a\000s)
+/Count 3 /Dest [ 196 0 R /XYZ 57.02362 747.0236 0 ] /First 290 0 R /Last 290 0 R /Next 293 0 R /Parent 248 0 R 
+  /Prev 278 0 R /Title (\376\377\0009\000\240\000\240\000\240\000S\000y\000n\000t\000a\000x\000 \000H\000i\000g\000h\000l\000i\000g\000h\000t\000i\000n\000g)
 >>
 endobj
 290 0 obj
 <<
-/Dest [ 195 0 R /XYZ 57.02362 270.6236 0 ] /Next 291 0 R /Parent 281 0 R /Prev 289 0 R /Title (\376\377\0008\000.\0005\000\240\000\240\000\240\000W\000i\000d\000o\000w\000s\000 \000a\000n\000d\000 \000O\000r\000p\000h\000a\000n\000s)
+/Count 2 /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /First 291 0 R /Last 292 0 R /Parent 289 0 R /Title (\376\377\0009\000.\0001\000\240\000\240\000\240\000F\000i\000l\000e\000 \000i\000n\000c\000l\000u\000s\000i\000o\000n)
 >>
 endobj
 291 0 obj
 <<
-/Dest [ 196 0 R /XYZ 57.02362 581.8236 0 ] /Parent 281 0 R /Prev 290 0 R /Title (\376\377\0008\000.\0006\000\240\000\240\000\240\000T\000a\000b\000l\000e\000 \000S\000t\000y\000l\000e\000s)
+/Dest [ 200 0 R /XYZ 57.02362 633.8236 0 ] /Next 292 0 R /Parent 290 0 R /Title (\376\377\0009\000.\0001\000.\0001\000\240\000\240\000\240\000I\000n\000c\000l\000u\000d\000e\000 \000w\000i\000t\000h\000 \000B\000o\000u\000n\000d\000a\000r\000i\000e\000s)
 >>
 endobj
 292 0 obj
 <<
-/Count 3 /Dest [ 200 0 R /XYZ 57.02362 747.0236 0 ] /First 293 0 R /Last 293 0 R /Next 296 0 R /Parent 259 0 R 
-  /Prev 281 0 R /Title (\376\377\0009\000\240\000\240\000\240\000S\000y\000n\000t\000a\000x\000 \000H\000i\000g\000h\000l\000i\000g\000h\000t\000i\000n\000g)
+/Dest [ 200 0 R /XYZ 57.02362 464.8236 0 ] /Parent 290 0 R /Prev 291 0 R /Title (\376\377\0009\000.\0001\000.\0002\000\240\000\240\000\240\000O\000p\000t\000i\000o\000n\000s)
 >>
 endobj
 293 0 obj
 <<
-/Count 2 /Dest [ 204 0 R /XYZ 57.02362 747.0236 0 ] /First 294 0 R /Last 295 0 R /Parent 292 0 R /Title (\376\377\0009\000.\0001\000\240\000\240\000\240\000F\000i\000l\000e\000 \000i\000n\000c\000l\000u\000s\000i\000o\000n)
+/Count 6 /Dest [ 203 0 R /XYZ 57.02362 747.0236 0 ] /First 294 0 R /Last 295 0 R /Next 300 0 R /Parent 248 0 R 
+  /Prev 289 0 R /Title (\376\377\0001\0000\000\240\000\240\000\240\000F\000o\000n\000t\000s)
 >>
 endobj
 294 0 obj
 <<
-/Dest [ 204 0 R /XYZ 57.02362 633.8236 0 ] /Next 295 0 R /Parent 293 0 R /Title (\376\377\0009\000.\0001\000.\0001\000\240\000\240\000\240\000I\000n\000c\000l\000u\000d\000e\000 \000w\000i\000t\000h\000 \000B\000o\000u\000n\000d\000a\000r\000i\000e\000s)
+/Dest [ 203 0 R /XYZ 57.02362 684.0236 0 ] /Next 295 0 R /Parent 293 0 R /Title (\376\377\0001\0000\000.\0001\000\240\000\240\000\240\000S\000t\000a\000n\000d\000a\000r\000d\000 \000P\000D\000F\000 \000F\000o\000n\000t\000s)
 >>
 endobj
 295 0 obj
 <<
-/Dest [ 204 0 R /XYZ 57.02362 228.4236 0 ] /Parent 293 0 R /Prev 294 0 R /Title (\376\377\0009\000.\0001\000.\0002\000\240\000\240\000\240\000O\000p\000t\000i\000o\000n\000s)
+/Count 4 /Dest [ 203 0 R /XYZ 57.02362 384.0236 0 ] /First 296 0 R /Last 299 0 R /Parent 293 0 R /Prev 294 0 R 
+  /Title (\376\377\0001\0000\000.\0002\000\240\000\240\000\240\000F\000o\000n\000t\000 \000E\000m\000b\000e\000d\000d\000i\000n\000g)
 >>
 endobj
 296 0 obj
 <<
-/Count 6 /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /First 297 0 R /Last 298 0 R /Next 303 0 R /Parent 259 0 R 
-  /Prev 292 0 R /Title (\376\377\0001\0000\000\240\000\240\000\240\000F\000o\000n\000t\000s)
+/Count 2 /Dest [ 203 0 R /XYZ 57.02362 324.0236 0 ] /First 297 0 R /Last 298 0 R /Next 299 0 R /Parent 295 0 R 
+  /Title (\376\377\0001\0000\000.\0002\000.\0001\000\240\000\240\000\240\000T\000h\000e\000 \000E\000a\000s\000y\000 \000W\000a\000y)
 >>
 endobj
 297 0 obj
 <<
-/Dest [ 207 0 R /XYZ 57.02362 684.0236 0 ] /Next 298 0 R /Parent 296 0 R /Title (\376\377\0001\0000\000.\0001\000\240\000\240\000\240\000S\000t\000a\000n\000d\000a\000r\000d\000 \000P\000D\000F\000 \000F\000o\000n\000t\000s)
+/Dest [ 203 0 R /XYZ 57.02362 195.8236 0 ] /Next 298 0 R /Parent 296 0 R /Title (\376\377\0001\0000\000.\0002\000.\0001\000.\0001\000\240\000\240\000\240\000F\000o\000n\000t\000y\000 \000i\000s\000 \000a\000 \000T\000r\000u\000e\000 \000T\000y\000p\000e\000 \000f\000o\000n\000t\000:)
 >>
 endobj
 298 0 obj
 <<
-/Count 4 /Dest [ 207 0 R /XYZ 57.02362 384.0236 0 ] /First 299 0 R /Last 302 0 R /Parent 296 0 R /Prev 297 0 R 
-  /Title (\376\377\0001\0000\000.\0002\000\240\000\240\000\240\000F\000o\000n\000t\000 \000E\000m\000b\000e\000d\000d\000i\000n\000g)
+/Dest [ 204 0 R /XYZ 57.02362 609.8236 0 ] /Parent 296 0 R /Prev 297 0 R /Title (\376\377\0001\0000\000.\0002\000.\0001\000.\0002\000\240\000\240\000\240\000F\000o\000n\000t\000y\000 \000i\000s\000 \000a\000 \000T\000y\000p\000e\000 \0001\000 \000f\000o\000n\000t\000:)
 >>
 endobj
 299 0 obj
 <<
-/Count 2 /Dest [ 207 0 R /XYZ 57.02362 324.0236 0 ] /First 300 0 R /Last 301 0 R /Next 302 0 R /Parent 298 0 R 
-  /Title (\376\377\0001\0000\000.\0002\000.\0001\000\240\000\240\000\240\000T\000h\000e\000 \000E\000a\000s\000y\000 \000W\000a\000y)
+/Dest [ 204 0 R /XYZ 57.02362 139.0236 0 ] /Parent 295 0 R /Prev 296 0 R /Title (\376\377\0001\0000\000.\0002\000.\0002\000\240\000\240\000\240\000T\000h\000e\000 \000H\000a\000r\000d\000e\000r\000 \000W\000a\000y\000 \000\(\000T\000r\000u\000e\000 \000T\000y\000p\000e\000\))
 >>
 endobj
 300 0 obj
 <<
-/Dest [ 207 0 R /XYZ 57.02362 195.8236 0 ] /Next 301 0 R /Parent 299 0 R /Title (\376\377\0001\0000\000.\0002\000.\0001\000.\0001\000\240\000\240\000\240\000F\000o\000n\000t\000y\000 \000i\000s\000 \000a\000 \000T\000r\000u\000e\000 \000T\000y\000p\000e\000 \000f\000o\000n\000t\000:)
+/Count 7 /Dest [ 207 0 R /XYZ 57.02362 747.0236 0 ] /First 301 0 R /Last 307 0 R /Next 308 0 R /Parent 248 0 R 
+  /Prev 293 0 R /Title (\376\377\0001\0001\000\240\000\240\000\240\000R\000a\000w\000 \000D\000i\000r\000e\000c\000t\000i\000v\000e)
 >>
 endobj
 301 0 obj
 <<
-/Dest [ 208 0 R /XYZ 57.02362 609.8236 0 ] /Parent 299 0 R /Prev 300 0 R /Title (\376\377\0001\0000\000.\0002\000.\0001\000.\0002\000\240\000\240\000\240\000F\000o\000n\000t\000y\000 \000i\000s\000 \000a\000 \000T\000y\000p\000e\000 \0001\000 \000f\000o\000n\000t\000:)
+/Dest [ 207 0 R /XYZ 57.02362 714.0236 0 ] /Next 302 0 R /Parent 300 0 R /Title (\376\377\0001\0001\000.\0001\000\240\000\240\000\240\000R\000a\000w\000 \000P\000D\000F)
 >>
 endobj
 302 0 obj
 <<
-/Dest [ 208 0 R /XYZ 57.02362 139.0236 0 ] /Parent 298 0 R /Prev 299 0 R /Title (\376\377\0001\0000\000.\0002\000.\0002\000\240\000\240\000\240\000T\000h\000e\000 \000H\000a\000r\000d\000e\000r\000 \000W\000a\000y\000 \000\(\000T\000r\000u\000e\000 \000T\000y\000p\000e\000\))
+/Dest [ 207 0 R /XYZ 57.02362 402.8236 0 ] /Next 303 0 R /Parent 300 0 R /Prev 301 0 R /Title (\376\377\0001\0001\000.\0002\000\240\000\240\000\240\000P\000a\000g\000e\000 \000C\000o\000u\000n\000t\000e\000r\000s)
 >>
 endobj
 303 0 obj
 <<
-/Count 7 /Dest [ 211 0 R /XYZ 57.02362 747.0236 0 ] /First 304 0 R /Last 310 0 R /Next 311 0 R /Parent 259 0 R 
-  /Prev 296 0 R /Title (\376\377\0001\0001\000\240\000\240\000\240\000R\000a\000w\000 \000D\000i\000r\000e\000c\000t\000i\000v\000e)
+/Dest [ 208 0 R /XYZ 57.02362 577.0236 0 ] /Next 304 0 R /Parent 300 0 R /Prev 302 0 R /Title (\376\377\0001\0001\000.\0003\000\240\000\240\000\240\000P\000a\000g\000e\000 \000B\000r\000e\000a\000k\000s)
 >>
 endobj
 304 0 obj
 <<
-/Dest [ 211 0 R /XYZ 57.02362 714.0236 0 ] /Next 305 0 R /Parent 303 0 R /Title (\376\377\0001\0001\000.\0001\000\240\000\240\000\240\000R\000a\000w\000 \000P\000D\000F)
+/Dest [ 208 0 R /XYZ 57.02362 254.4236 0 ] /Next 305 0 R /Parent 300 0 R /Prev 303 0 R /Title (\376\377\0001\0001\000.\0004\000\240\000\240\000\240\000F\000r\000a\000m\000e\000 \000B\000r\000e\000a\000k\000s)
 >>
 endobj
 305 0 obj
 <<
-/Dest [ 211 0 R /XYZ 57.02362 402.8236 0 ] /Next 306 0 R /Parent 303 0 R /Prev 304 0 R /Title (\376\377\0001\0001\000.\0002\000\240\000\240\000\240\000P\000a\000g\000e\000 \000C\000o\000u\000n\000t\000e\000r\000s)
+/Dest [ 209 0 R /XYZ 57.02362 747.0236 0 ] /Next 306 0 R /Parent 300 0 R /Prev 304 0 R /Title (\376\377\0001\0001\000.\0005\000\240\000\240\000\240\000P\000a\000g\000e\000 \000T\000r\000a\000n\000s\000i\000t\000i\000o\000n\000s)
 >>
 endobj
 306 0 obj
 <<
-/Dest [ 212 0 R /XYZ 57.02362 577.0236 0 ] /Next 307 0 R /Parent 303 0 R /Prev 305 0 R /Title (\376\377\0001\0001\000.\0003\000\240\000\240\000\240\000P\000a\000g\000e\000 \000B\000r\000e\000a\000k\000s)
+/Dest [ 209 0 R /XYZ 57.02362 178.4236 0 ] /Next 307 0 R /Parent 300 0 R /Prev 305 0 R /Title (\376\377\0001\0001\000.\0006\000\240\000\240\000\240\000T\000e\000x\000t\000 \000A\000n\000n\000o\000t\000a\000t\000i\000o\000n\000s)
 >>
 endobj
 307 0 obj
 <<
-/Dest [ 212 0 R /XYZ 57.02362 254.4236 0 ] /Next 308 0 R /Parent 303 0 R /Prev 306 0 R /Title (\376\377\0001\0001\000.\0004\000\240\000\240\000\240\000F\000r\000a\000m\000e\000 \000B\000r\000e\000a\000k\000s)
+/Dest [ 210 0 R /XYZ 57.02362 723.0236 0 ] /Parent 300 0 R /Prev 306 0 R /Title (\376\377\0001\0001\000.\0007\000\240\000\240\000\240\000R\000a\000w\000 \000H\000T\000M\000L)
 >>
 endobj
 308 0 obj
 <<
-/Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Next 309 0 R /Parent 303 0 R /Prev 307 0 R /Title (\376\377\0001\0001\000.\0005\000\240\000\240\000\240\000P\000a\000g\000e\000 \000T\000r\000a\000n\000s\000i\000t\000i\000o\000n\000s)
+/Dest [ 212 0 R /XYZ 57.02362 747.0236 0 ] /Next 309 0 R /Parent 248 0 R /Prev 300 0 R /Title (\376\377\0001\0002\000\240\000\240\000\240\000T\000h\000e\000 \000c\000o\000u\000n\000t\000e\000r\000 \000r\000o\000l\000e)
 >>
 endobj
 309 0 obj
 <<
-/Dest [ 213 0 R /XYZ 57.02362 178.4236 0 ] /Next 310 0 R /Parent 303 0 R /Prev 308 0 R /Title (\376\377\0001\0001\000.\0006\000\240\000\240\000\240\000T\000e\000x\000t\000 \000A\000n\000n\000o\000t\000a\000t\000i\000o\000n\000s)
+/Dest [ 213 0 R /XYZ 57.02362 747.0236 0 ] /Next 310 0 R /Parent 248 0 R /Prev 308 0 R /Title (\376\377\0001\0003\000\240\000\240\000\240\000T\000h\000e\000 \000v\000e\000r\000s\000i\000o\000n\000,\000 \000r\000e\000v\000i\000s\000i\000o\000n\000 \000r\000o\000l\000e\000s)
 >>
 endobj
 310 0 obj
 <<
-/Dest [ 214 0 R /XYZ 57.02362 723.0236 0 ] /Parent 303 0 R /Prev 309 0 R /Title (\376\377\0001\0001\000.\0007\000\240\000\240\000\240\000R\000a\000w\000 \000H\000T\000M\000L)
+/Dest [ 214 0 R /XYZ 57.02362 747.0236 0 ] /Next 311 0 R /Parent 248 0 R /Prev 309 0 R /Title (\376\377\0001\0004\000\240\000\240\000\240\000T\000h\000e\000 \000o\000d\000d\000e\000v\000e\000n\000 \000d\000i\000r\000e\000c\000t\000i\000v\000e)
 >>
 endobj
 311 0 obj
 <<
-/Dest [ 216 0 R /XYZ 57.02362 747.0236 0 ] /Next 312 0 R /Parent 259 0 R /Prev 303 0 R /Title (\376\377\0001\0002\000\240\000\240\000\240\000T\000h\000e\000 \000c\000o\000u\000n\000t\000e\000r\000 \000r\000o\000l\000e)
+/Dest [ 219 0 R /XYZ 57.02362 747.0236 0 ] /Next 312 0 R /Parent 248 0 R /Prev 310 0 R /Title (\376\377\0001\0005\000\240\000\240\000\240\000M\000a\000t\000h\000e\000m\000a\000t\000i\000c\000s)
 >>
 endobj
 312 0 obj
 <<
-/Dest [ 217 0 R /XYZ 57.02362 747.0236 0 ] /Next 313 0 R /Parent 259 0 R /Prev 311 0 R /Title (\376\377\0001\0003\000\240\000\240\000\240\000T\000h\000e\000 \000v\000e\000r\000s\000i\000o\000n\000,\000 \000r\000e\000v\000i\000s\000i\000o\000n\000 \000r\000o\000l\000e\000s)
+/Dest [ 220 0 R /XYZ 57.02362 747.0236 0 ] /Next 313 0 R /Parent 248 0 R /Prev 311 0 R /Title (\376\377\0001\0006\000\240\000\240\000\240\000H\000y\000p\000h\000e\000n\000a\000t\000i\000o\000n)
 >>
 endobj
 313 0 obj
 <<
-/Dest [ 218 0 R /XYZ 57.02362 747.0236 0 ] /Next 314 0 R /Parent 259 0 R /Prev 312 0 R /Title (\376\377\0001\0004\000\240\000\240\000\240\000T\000h\000e\000 \000o\000d\000d\000e\000v\000e\000n\000 \000d\000i\000r\000e\000c\000t\000i\000v\000e)
+/Dest [ 222 0 R /XYZ 57.02362 747.0236 0 ] /Next 314 0 R /Parent 248 0 R /Prev 312 0 R /Title (\376\377\0001\0007\000\240\000\240\000\240\000S\000m\000a\000r\000t\000 \000Q\000u\000o\000t\000e\000s)
 >>
 endobj
 314 0 obj
 <<
-/Dest [ 223 0 R /XYZ 57.02362 747.0236 0 ] /Next 315 0 R /Parent 259 0 R /Prev 313 0 R /Title (\376\377\0001\0005\000\240\000\240\000\240\000M\000a\000t\000h\000e\000m\000a\000t\000i\000c\000s)
+/Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Next 315 0 R /Parent 248 0 R /Prev 313 0 R /Title (\376\377\0001\0008\000\240\000\240\000\240\000S\000p\000h\000i\000n\000x)
 >>
 endobj
 315 0 obj
 <<
-/Dest [ 224 0 R /XYZ 57.02362 747.0236 0 ] /Next 316 0 R /Parent 259 0 R /Prev 314 0 R /Title (\376\377\0001\0006\000\240\000\240\000\240\000H\000y\000p\000h\000e\000n\000a\000t\000i\000o\000n)
+/Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Next 316 0 R /Parent 248 0 R /Prev 314 0 R /Title (\376\377\0001\0009\000\240\000\240\000\240\000E\000x\000t\000e\000n\000s\000i\000o\000n\000s)
 >>
 endobj
 316 0 obj
 <<
-/Dest [ 226 0 R /XYZ 57.02362 747.0236 0 ] /Next 317 0 R /Parent 259 0 R /Prev 315 0 R /Title (\376\377\0001\0007\000\240\000\240\000\240\000S\000m\000a\000r\000t\000 \000Q\000u\000o\000t\000e\000s)
+/Dest [ 230 0 R /XYZ 57.02362 747.0236 0 ] /Next 317 0 R /Parent 248 0 R /Prev 315 0 R /Title (\376\377\0002\0000\000\240\000\240\000\240\000D\000e\000v\000e\000l\000o\000p\000e\000r\000s)
 >>
 endobj
 317 0 obj
 <<
-/Dest [ 228 0 R /XYZ 57.02362 747.0236 0 ] /Next 318 0 R /Parent 259 0 R /Prev 316 0 R /Title (\376\377\0001\0008\000\240\000\240\000\240\000S\000p\000h\000i\000n\000x)
+/Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /Parent 248 0 R /Prev 316 0 R /Title (\376\377\0002\0001\000\240\000\240\000\240\000L\000i\000c\000e\000n\000s\000e\000s)
 >>
 endobj
 318 0 obj
 <<
-/Count 2 /Dest [ 231 0 R /XYZ 57.02362 747.0236 0 ] /First 319 0 R /Last 320 0 R /Next 321 0 R /Parent 259 0 R 
-  /Prev 317 0 R /Title (\376\377\0001\0009\000\240\000\240\000\240\000E\000x\000t\000e\000n\000s\000i\000o\000n\000s)
+/Count 49 /Kids [ 4 0 R 87 0 R 146 0 R 152 0 R 154 0 R 155 0 R 157 0 R 160 0 R 161 0 R 165 0 R 
+  166 0 R 170 0 R 175 0 R 176 0 R 178 0 R 179 0 R 180 0 R 183 0 R 185 0 R 187 0 R 
+  188 0 R 189 0 R 191 0 R 192 0 R 193 0 R 196 0 R 198 0 R 199 0 R 200 0 R 203 0 R 
+  204 0 R 206 0 R 207 0 R 208 0 R 209 0 R 210 0 R 212 0 R 213 0 R 214 0 R 219 0 R 
+  220 0 R 222 0 R 224 0 R 225 0 R 226 0 R 228 0 R 230 0 R 231 0 R 233 0 R ] /Type /Pages
 >>
 endobj
 319 0 obj
-<<
-/Dest [ 231 0 R /XYZ 57.02362 666.0236 0 ] /Next 320 0 R /Parent 318 0 R /Title (\376\377\0001\0009\000.\0001\000\240\000\240\000\240\000P\000r\000e\000p\000r\000o\000c\000e\000s\000s\000 \000\(\000-\000e\000&\000n\000b\000s\000p\000;\000p\000r\000e\000p\000r\000o\000c\000e\000s\000s\000\))
->>
-endobj
-320 0 obj
-<<
-/Dest [ 232 0 R /XYZ 57.02362 568.6772 0 ] /Parent 318 0 R /Prev 319 0 R /Title (\376\377\0001\0009\000.\0002\000\240\000\240\000\240\000D\000o\000t\000t\000e\000d\000_\000T\000O\000C\000 \000\(\000-\000e\000&\000n\000b\000s\000p\000;\000d\000o\000t\000t\000e\000d\000_\000t\000o\000c\000\))
->>
-endobj
-321 0 obj
-<<
-/Count 1 /Dest [ 234 0 R /XYZ 57.02362 747.0236 0 ] /First 322 0 R /Last 322 0 R /Next 323 0 R /Parent 259 0 R 
-  /Prev 318 0 R /Title (\376\377\0002\0000\000\240\000\240\000\240\000D\000e\000v\000e\000l\000o\000p\000e\000r\000s)
->>
-endobj
-322 0 obj
-<<
-/Dest [ 234 0 R /XYZ 57.02362 714.0236 0 ] /Parent 321 0 R /Title (\376\377\0002\0000\000.\0001\000\240\000\240\000\240\000G\000u\000i\000d\000e\000l\000i\000n\000e\000s)
->>
-endobj
-323 0 obj
-<<
-/Count 6 /Dest [ 237 0 R /XYZ 57.02362 747.0236 0 ] /First 324 0 R /Last 327 0 R /Next 330 0 R /Parent 259 0 R 
-  /Prev 321 0 R /Title (\376\377\0002\0001\000\240\000\240\000\240\000I\000n\000i\000t\000i\000a\000l\000 \000c\000h\000e\000c\000k\000o\000u\000t)
->>
-endobj
-324 0 obj
-<<
-/Dest [ 237 0 R /XYZ 57.02362 438.362 0 ] /Next 325 0 R /Parent 323 0 R /Title (\376\377\0002\0001\000.\0001\000\240\000\240\000\240\000G\000i\000t\000 \000c\000o\000n\000f\000i\000g)
->>
-endobj
-325 0 obj
-<<
-/Dest [ 237 0 R /XYZ 57.02362 315.162 0 ] /Next 326 0 R /Parent 323 0 R /Prev 324 0 R /Title (\376\377\0002\0001\000.\0002\000\240\000\240\000\240\000P\000r\000e\000-\000c\000o\000m\000m\000i\000t)
->>
-endobj
-326 0 obj
-<<
-/Dest [ 237 0 R /XYZ 57.02362 136.762 0 ] /Next 327 0 R /Parent 323 0 R /Prev 325 0 R /Title (\376\377\0002\0001\000.\0003\000\240\000\240\000\240\000C\000o\000n\000t\000i\000n\000u\000o\000u\000s\000 \000I\000n\000t\000e\000g\000r\000a\000t\000i\000o\000n)
->>
-endobj
-327 0 obj
-<<
-/Count 2 /Dest [ 241 0 R /XYZ 57.02362 747.0236 0 ] /First 328 0 R /Last 329 0 R /Parent 323 0 R /Prev 326 0 R 
-  /Title (\376\377\0002\0001\000.\0004\000\240\000\240\000\240\000R\000u\000n\000n\000i\000n\000g\000 \000t\000e\000s\000t\000s)
->>
-endobj
-328 0 obj
-<<
-/Dest [ 241 0 R /XYZ 57.02362 475.4236 0 ] /Next 329 0 R /Parent 327 0 R /Title (\376\377\0002\0001\000.\0004\000.\0001\000\240\000\240\000\240\000R\000u\000n\000n\000i\000n\000g\000 \000a\000 \000s\000i\000n\000g\000l\000e\000 \000t\000e\000s\000t)
->>
-endobj
-329 0 obj
-<<
-/Dest [ 241 0 R /XYZ 57.02362 377.2236 0 ] /Parent 327 0 R /Prev 328 0 R /Title (\376\377\0002\0001\000.\0004\000.\0002\000\240\000\240\000\240\000S\000k\000i\000p\000p\000i\000n\000g\000 \000t\000e\000s\000t\000s)
->>
-endobj
-330 0 obj
-<<
-/Dest [ 242 0 R /XYZ 57.02362 747.0236 0 ] /Parent 259 0 R /Prev 323 0 R /Title (\376\377\0002\0002\000\240\000\240\000\240\000L\000i\000c\000e\000n\000s\000e\000s)
->>
-endobj
-331 0 obj
-<<
-/Count 52 /Kids [ 4 0 R 87 0 R 151 0 R 156 0 R 157 0 R 158 0 R 162 0 R 163 0 R 164 0 R 168 0 R 
-  169 0 R 173 0 R 179 0 R 180 0 R 182 0 R 183 0 R 184 0 R 187 0 R 189 0 R 191 0 R 
-  192 0 R 193 0 R 195 0 R 196 0 R 197 0 R 200 0 R 202 0 R 203 0 R 204 0 R 207 0 R 
-  208 0 R 210 0 R 211 0 R 212 0 R 213 0 R 214 0 R 216 0 R 217 0 R 218 0 R 223 0 R 
-  224 0 R 226 0 R 228 0 R 229 0 R 230 0 R 231 0 R 232 0 R 234 0 R 237 0 R 241 0 R 
-  242 0 R 244 0 R ] /Type /Pages
->>
-endobj
-332 0 obj
 <<
 /Length 667
 >>
@@ -2989,7 +2897,7 @@ q
 1 0 0 1 57.02362 239.263 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 195.8742 0 Td (Version 0.102 \(final\)) Tj T* -195.8742 0 Td ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 195.8742 0 Td (Version 0.103 \(final\)) Tj T* -195.8742 0 Td ET
 Q
 Q
 q
@@ -2998,9 +2906,9 @@ Q
  
 endstream
 endobj
-333 0 obj
+320 0 obj
 <<
-/Length 9869
+/Length 9894
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -3057,482 +2965,482 @@ Q
 q
 1 0 0 1 0 586.2 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (3   Configuration File) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.1   General Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 586.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (7) Tj T* -67.274 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 570 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (4   Pipe usage) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.2   File and Configuration) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 570 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 553.8 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (5   Images) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.3   Styling Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 553.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 537.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.1   Inline) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.4   PDF Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 537.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 521.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.2   Supported Image Types) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.5   Formatting Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 521.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (6) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 505.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.3   Image Size) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (2.6   Miscellaneous Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 505.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (6) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 489 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (6   Styling ReStructuredText) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (3   Configuration File) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 489 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (7) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 472.8 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.1   Applying Styles) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (3.1   Configuration Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 472.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (7) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 456.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.2   Headers and Footers) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (3.2   Example Configuration File) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 456.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (8) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 440.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.3   Footnotes) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (4   Pipe usage) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 440.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (13) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 424.2 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (7   Customizing PDF Output) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (5   Images) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 424.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 408 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.1   Using Stylesheets) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.1   Inline) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 408 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 391.8 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.2   Included StyleSheets) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.2   Supported Image Types) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 391.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 375.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.3   Default Stylesheet) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (5.3   Image Size) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 375.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (10) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 359.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.4   Migrating Stylesheet Format) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (6   Styling ReStructuredText) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 359.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 343.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5   Migrating to the New Default Stylesheet) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.1   Applying Styles) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 343.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 327 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5.1   Updated Font Alias Names) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.2   Headers and Footers) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 327 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 310.8 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5.2   Updated Pate Template Names) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (6.3   Footnotes) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 310.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (16) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (13) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 294.6 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (8   Creating Stylesheets) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (7   Customizing PDF Output) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 294.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 278.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.1   Styles in Detail) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.1   Using Stylesheets) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 278.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 262.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2   Style Elements) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.2   Included StyleSheets) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 262.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (18) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 246 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2.1   Inline Styles) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.3   Default Stylesheet) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 246 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 229.8 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2.2   Lists) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.4   Migrating Stylesheet Format) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 229.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 213.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3   Page Layout) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5   Migrating to the New Default Stylesheet) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 213.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 197.4 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3.1   Page Setup) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5.1   Updated Font Alias Names) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 197.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 181.2 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3.2   Page Templates) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (7.5.2   Updated Pate Template Names) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 181.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (22) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (16) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 165 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.4   Font Alias) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (8   Creating Stylesheets) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 165 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 148.8 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.5   Widows and Orphans) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.1   Styles in Detail) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 148.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 132.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.6   Table Styles) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2   Style Elements) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 132.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (24) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (18) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 116.4 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (9   Syntax Highlighting) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2.1   Inline Styles) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 116.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (26) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 100.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1   File inclusion) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.2.2   Lists) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 100.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 84 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1.1   Include with Boundaries) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3   Page Layout) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 84 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 67.8 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1.2   Options) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3.1   Page Setup) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 67.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 51.6 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (10   Fonts) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.3.2   Page Templates) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 51.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (22) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 35.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.1   Standard PDF Fonts) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.4   Font Alias) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 35.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 19.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2   Font Embedding) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.5   Widows and Orphans) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 19.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 3 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1   The Easy Way) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (8.6   Table Styles) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 3 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (24) Tj T* -62.548 0 Td ET
 Q
 Q
 q
@@ -3579,418 +3487,392 @@ Q
  
 endstream
 endobj
-334 0 obj
+321 0 obj
 <<
-/Length 7926
+/Length 7293
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
-1 0 0 1 57.02362 244.8236 cm
+1 0 0 1 57.02362 277.2236 cm
 q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 0 489 cm
-q
-BT 1 0 0 1 60 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1.1   Fonty is a True Type font:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 409.2283 489 cm
-q
-0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
-Q
-Q
-q
-1 0 0 1 0 472.8 cm
-q
-BT 1 0 0 1 60 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1.2   Fonty is a Type 1 font:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 409.2283 472.8 cm
-q
-0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
-Q
-Q
-q
 1 0 0 1 0 456.6 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.2   The Harder Way \(True Type\)) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (9   Syntax Highlighting) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 456.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (26) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 440.4 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (11   Raw Directive) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1   File inclusion) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 440.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 424.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.1   Raw PDF) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1.1   Include with Boundaries) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 424.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 408 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.2   Page Counters) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (9.1.2   Options) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 408 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (29) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 391.8 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.3   Page Breaks) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (10   Fonts) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 391.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (34) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 375.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.4   Frame Breaks) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.1   Standard PDF Fonts) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 375.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (34) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 359.4 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.5   Page Transitions) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2   Font Embedding) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 359.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 343.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.6   Text Annotations) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1   The Easy Way) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 343.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 327 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.7   Raw HTML) Tj T* ET
+BT 1 0 0 1 60 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1.1   Fonty is a True Type font:) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 327 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (30) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 310.8 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (12   The counter role) Tj T* ET
+BT 1 0 0 1 60 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.1.2   Fonty is a Type 1 font:) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 310.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (37) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 294.6 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (13   The version, revision roles) Tj T* ET
+BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (10.2.2   The Harder Way \(True Type\)) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 294.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (38) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 278.4 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (14   The oddeven directive) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (11   Raw Directive) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 278.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 262.2 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (15   Mathematics) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.1   Raw PDF) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 262.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (40) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 246 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (16   Hyphenation) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.2   Page Counters) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 246 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (41) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 229.8 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (17   Smart Quotes) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.3   Page Breaks) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 229.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (34) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 213.6 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (18   Sphinx) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.4   Frame Breaks) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 213.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (43) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (34) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 197.4 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (19   Extensions) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.5   Page Transitions) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 197.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (46) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 181.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (19.1   Preprocess \() Tj /F5 8.5 Tf 0 0 0 rg (-e) Tj ( ) Tj (preprocess) Tj /F1 8.5 Tf 0 .4 .6 rg (\)) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.6   Text Annotations) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 181.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (46) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 165 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (19.2   Dotted_TOC \() Tj /F5 8.5 Tf 0 0 0 rg (-e) Tj ( ) Tj (dotted_toc) Tj /F1 8.5 Tf 0 .4 .6 rg (\)) Tj T* ET
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (11.7   Raw HTML) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 165 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (47) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 148.8 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (20   Developers) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (12   The counter role) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 148.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (48) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (37) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 132.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (20.1   Guidelines) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (13   The version, revision roles) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 132.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (48) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (38) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 116.4 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (21   Initial checkout) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (14   The oddeven directive) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 116.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (49) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 100.2 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.1   Git config) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (15   Mathematics) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 100.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (49) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (40) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 84 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.2   Pre-commit) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (16   Hyphenation) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 84 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (49) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (41) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 67.8 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.3   Continuous Integration) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (17   Smart Quotes) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 67.8 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (49) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 51.6 cm
 q
-BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.4   Running tests) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (18   Sphinx) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 51.6 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (50) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (43) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 35.4 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.4.1   Running a single test) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (19   Extensions) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 35.4 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (50) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (46) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 19.2 cm
 q
-BT 1 0 0 1 40 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (21.4.2   Skipping tests) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (20   Developers) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 19.2 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (50) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (47) Tj T* -62.548 0 Td ET
 Q
 Q
 q
 1 0 0 1 0 3 cm
 q
-BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (22   Licenses) Tj T* ET
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (21   Licenses) Tj T* ET
 Q
 Q
 q
 1 0 0 1 409.2283 3 cm
 q
 0 .4 .6 rg
-BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (51) Tj T* -62.548 0 Td ET
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (48) Tj T* -62.548 0 Td ET
 Q
 Q
 q
@@ -3998,7 +3880,7 @@ Q
 Q
 Q
 q
-1 0 0 1 57.02362 244.8236 cm
+1 0 0 1 57.02362 277.2236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -4043,7 +3925,7 @@ Q
  
 endstream
 endobj
-335 0 obj
+322 0 obj
 <<
 /Length 4008
 >>
@@ -4269,9 +4151,9 @@ Q
  
 endstream
 endobj
-336 0 obj
+323 0 obj
 <<
-/Length 12293
+/Length 9854
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -4282,958 +4164,511 @@ BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (2   Command li
 Q
 Q
 q
-1 0 0 1 57.02362 704.8236 cm
+1 0 0 1 57.02362 708.0236 cm
 q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Use the following options to control the output of ) Tj /F6 10 Tf (rst2pdf) Tj /F1 10 Tf ( on the command line.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.1   General Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+Q
+q
+1 0 0 1 57.02362 558.0236 cm
+q
+1 1 1 rg
+n 0 108 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 90 481.2283 -18 re f*
+1 1 1 rg
+n 0 72 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 54 481.2283 -18 re f*
+1 1 1 rg
+n 0 36 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 18 481.2283 -18 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 93 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
+Q
+Q
+q
+1 0 0 1 246.6142 93 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
+Q
+Q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 6 3 cm
+1 0 0 1 6 75 cm
 q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-h, --help) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Show this help message and exit) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 689.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--config=FILE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Config file to use. Default=~/.rst2pdf/config) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 674.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-o FILE, --output=FILE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Write the PDF to FILE) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 647.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 15.67143 cm
-q
-q
-.928571 0 0 .928571 0 0 cm
-q
-1 0 0 1 .1 .107692 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-s STYLESHEETS, --stylesheets=STYLESHEETS) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 4.374835 Tw (A comma-separated list of custom stylesheets.) Tj T* 0 Tw (Default="") Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 620.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--stylesheet-path=FOLDERLIST) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 4.313453 Tw (A colon-separated list of folders to search for) Tj T* 0 Tw (stylesheets. Default="") Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 605.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-c, --compressed) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Create a compressed PDF. Default=False) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 590.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--print-stylesheet) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print the default stylesheet and exit) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 574.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--font-folder=FOLDER) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Search this folder for fonts. \(Deprecated\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 547.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--font-path=FOLDERLIST) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .369272 Tw (A colon-separated list of folders to search for fonts.) Tj T* 0 Tw (Default="") Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 532.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--baseurl=URL) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The base URL for relative URLs.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 505.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-l LANG, --language=LANG) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .972025 Tw (Language to be used for hyphenation and docutils) Tj T* 0 Tw (localization. Default=None) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 490.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--header=HEADER) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page header if not specified in the document.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 475.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--footer=FOOTER) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page footer if not specified in the document.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 436.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 26.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--section-header-depth=N) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .849417 Tw (Sections up to this dept will be used in the header) Tj T* 0 Tw 8.871043 Tw (and footer's replacement of ###Section###.) Tj T* 0 Tw (Default=2) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 409.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--smart-quotes=VALUE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .578022 Tw (Try to convert ASCII quotes, ellipsis and dashes to) Tj T* 0 Tw (the typographically correct equivalent. Default=0) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 391.2236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The possible values are:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 385.2236 cm
-Q
-q
-1 0 0 1 57.02362 385.2236 cm
-Q
-q
-1 0 0 1 57.02362 373.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (1.) Tj T* -2 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Suppress all transformations. \(Do nothing.\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 367.2236 cm
-Q
-q
-1 0 0 1 57.02362 343.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (2.) Tj T* -2 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 2.953543 Tw (Performs default SmartyPants transformations: quotes \(including backticks-style\), em-dashes, and) Tj T* 0 Tw (ellipses. "--" \(dash dash\) is used to signify an em-dash; there is no support for en-dashes.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 337.2236 cm
-Q
-q
-1 0 0 1 57.02362 313.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (3.) Tj T* -2 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.111547 Tw (Same as --smart-quotes=1, except that it uses the old-school typewriter shorthand for dashes: "--" \(dash) Tj T* 0 Tw (dash\) for en-dashes, "---" \(dash dash dash\) for em-dashes.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 307.2236 cm
-Q
-q
-1 0 0 1 57.02362 283.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (4.) Tj T* -2 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .76131 Tw (Same as --smart-quotes=2, but inverts the shorthand for dashes: "--" \(dash dash\) for em-dashes, and) Tj T* 0 Tw ("---" \(dash dash dash\) for en-dashes.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 283.2236 cm
-Q
-q
-1 0 0 1 57.02362 256.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--fit-literal-mode=MODE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 3.296417 Tw (What to do when a literal is too wide. One of) Tj T* 0 Tw (error,overflow,shrink,truncate. Default="shrink") Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 229.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--fit-background-mode=MODE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .881575 Tw (How to fit the background image to the page. One) Tj T* 0 Tw (of scale, scale_width or center. Default="center") Tj T* ET
-Q
-Q
-q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (-h,) Tj ( ) Tj (--help) Tj T* ET
 Q
 Q
-Q
-q
-1 0 0 1 57.02362 202.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--inline-links) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .027362 Tw (Shows target between parenthesis instead of active) Tj T* 0 Tw (link) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 187.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--repeat-table-rows) Tj T* ET
-Q
-Q
-Q
-Q
-Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 75 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Repeats header row for each splitted table) Tj T* ET
-Q
-Q
-q
-Q
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Show the help message and exit.) Tj T* ET
 Q
 Q
-q
-1 0 0 1 57.02362 171.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
 q
-1 0 0 1 .1 .1 cm
+1 0 0 1 6 57 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--raw-html) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--version) Tj T* ET
 Q
 Q
-Q
-Q
-Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 57 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Support embeddig raw HTML. Default: False) Tj T* ET
-Q
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print the version number and exit.) Tj T* ET
 Q
-q
-Q
 Q
-Q
-q
-1 0 0 1 57.02362 156.6236 cm
 q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
+1 0 0 1 6 39 cm
 q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-q, --quiet) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (-q,) Tj ( ) Tj (--quiet) Tj T* ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 39 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print less information.) Tj T* ET
 Q
 Q
 q
-Q
-Q
-Q
+1 0 0 1 6 21 cm
 q
-1 0 0 1 57.02362 141.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-v, --verbose) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (-v,) Tj ( ) Tj (--verbose) Tj T* ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 21 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print debug information.) Tj T* ET
 Q
 Q
 q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 126.2236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
 1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--very-verbose) Tj T* ET
 Q
 Q
-Q
-Q
-Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 3 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print even more debug information.) Tj T* ET
 Q
 Q
 q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 90 m 481.2283 90 l S
+n 0 72 m 481.2283 72 l S
+n 0 54 m 481.2283 54 l S
+n 0 36 m 481.2283 36 l S
+n 0 18 m 481.2283 18 l S
+n 240.6142 0 m 240.6142 108 l S
+n 0 108 m 481.2283 108 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 108 l S
+n 481.2283 0 m 481.2283 108 l S
 Q
 Q
 Q
 q
-1 0 0 1 57.02362 111.0236 cm
+1 0 0 1 57.02362 558.0236 cm
+Q
 q
+1 0 0 1 57.02362 528.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.2   File and Configuration) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 516.0236 cm
+Q
+q
+1 0 0 1 57.02362 444.0236 cm
+q
+1 1 1 rg
+n 0 72 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 54 481.2283 -18 re f*
+1 1 1 rg
+n 0 36 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 18 481.2283 -18 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
+Q
+Q
+q
+1 0 0 1 246.6142 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
+Q
+Q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
+1 0 0 1 6 39 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--config=FILE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 39 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Config file to use. Default: ) Tj /F5 10 Tf (~/.rst2pdf/config) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 21 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (-o) Tj ( ) Tj (FILE,) Tj ( ) Tj (--output=FILE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 21 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Write the PDF to ) Tj /F5 10 Tf (FILE) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
 1 0 0 1 6 3 cm
 q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--record-dependencies=FILE) Tj T* ET
+Q
+Q
 q
-1 0 0 1 0 0 cm
+1 0 0 1 246.6142 3 cm
 q
-1 0 0 1 .1 .1 cm
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Write output file dependencies to ) Tj /F5 10 Tf (FILE) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 54 m 481.2283 54 l S
+n 0 36 m 481.2283 36 l S
+n 0 18 m 481.2283 18 l S
+n 240.6142 0 m 240.6142 72 l S
+n 0 72 m 481.2283 72 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 72 l S
+n 481.2283 0 m 481.2283 72 l S
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 444.0236 cm
+Q
+q
+1 0 0 1 57.02362 414.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.3   Styling Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+1 1 1 rg
+n 0 126 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 108 481.2283 -30 re f*
+1 1 1 rg
+n 0 78 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 48 481.2283 -18 re f*
+1 1 1 rg
+n 0 30 481.2283 -30 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 111 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--version) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 111 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print version number and exit.) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
 Q
 Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 95.82362 cm
-q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 6 3 cm
+1 0 0 1 6 81 cm
 q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--no-footnote-backlinks) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (-s) Tj ( ) Tj (STYLESHEETS,) Tj ( ) Tj (--stylesheets=STYLESHE) Tj  T* (ETS) Tj T* ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 81 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (A comma-separated list of custom stylesheets.) Tj T* (Default: ) Tj /F5 10 Tf ("") Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 63 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Disable footnote backlinks. Default: False) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--stylesheet-path=FOLDERLIST) Tj T* ET
 Q
 Q
 q
+1 0 0 1 246.6142 51 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (A colon-separated list of folders to search for) Tj T* (stylesheets. Default: ) Tj /F5 10 Tf ("") Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--print-stylesheet) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Print the default stylesheet and exit.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--font-path=FOLDERLIST) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (A colon-separated list of folders to search for fonts.) Tj T* (Default: ) Tj /F5 10 Tf ("") Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 108 m 481.2283 108 l S
+n 0 78 m 481.2283 78 l S
+n 0 48 m 481.2283 48 l S
+n 0 30 m 481.2283 30 l S
+n 240.6142 0 m 240.6142 126 l S
+n 0 126 m 481.2283 126 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 126 l S
+n 481.2283 0 m 481.2283 126 l S
 Q
 Q
 Q
 q
-1 0 0 1 57.02362 80.62362 cm
+1 0 0 1 57.02362 276.0236 cm
+Q
 q
+1 0 0 1 57.02362 246.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.4   PDF Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 234.0236 cm
+Q
+q
+1 0 0 1 57.02362 66.02362 cm
+q
+1 1 1 rg
+n 0 168 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 150 481.2283 -18 re f*
+1 1 1 rg
+n 0 132 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 114 481.2283 -18 re f*
+1 1 1 rg
+n 0 96 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 78 481.2283 -30 re f*
+1 1 1 rg
+n 0 48 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 30 481.2283 -30 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 153 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
+Q
+Q
+q
+1 0 0 1 246.6142 153 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
+Q
+Q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 6 3 cm
+1 0 0 1 6 135 cm
 q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--inline-footnotes) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (-c,) Tj ( ) Tj (--compressed) Tj T* ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 135 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Create a compressed PDF. Default: ) Tj /F5 10 Tf (False) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 117 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Show footnotes inline. Default: True) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--baseurl=URL) Tj T* ET
 Q
 Q
 q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 65.42362 cm
+1 0 0 1 246.6142 117 cm
 q
 0 0 0 rg
-BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The base URL for relative URLs.) Tj T* ET
+Q
+Q
 q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
+1 0 0 1 6 99 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--default-dpi=NUMBER) Tj T* ET
-Q
-Q
-Q
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--header=HEADER) Tj T* ET
 Q
 Q
 q
-1 0 0 1 246.6142 3.2 cm
+1 0 0 1 246.6142 99 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (DPI for objects sized in pixels. Default=300) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page header if not specified in the document.) Tj T* ET
 Q
 Q
 q
+1 0 0 1 6 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--footer=FOOTER) Tj T* ET
 Q
 Q
+q
+1 0 0 1 246.6142 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page footer if not specified in the document.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--first-page-on-right) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 51 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (When using double-sided pages, the first page will) Tj T* (start on the right-hand side \(Book Style\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--blank-first-page) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL -0.047314 Tw (Add a blank page at the beginning of the document.) Tj T* 0 Tw ET
+Q
+Q
+q
+1 0 0 1 6 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--custom-cover=FILE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Template file used for the cover page. Default:) Tj T* /F5 10 Tf (cover.tmpl) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 150 m 481.2283 150 l S
+n 0 132 m 481.2283 132 l S
+n 0 114 m 481.2283 114 l S
+n 0 96 m 481.2283 96 l S
+n 0 78 m 481.2283 78 l S
+n 0 48 m 481.2283 48 l S
+n 0 30 m 481.2283 30 l S
+n 240.6142 0 m 240.6142 168 l S
+n 0 168 m 481.2283 168 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 168 l S
+n 481.2283 0 m 481.2283 168 l S
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 66.02362 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -5278,441 +4713,449 @@ Q
  
 endstream
 endobj
-337 0 obj
+324 0 obj
 <<
-/Length 6330
+/Length 8777
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
-1 0 0 1 57.02362 720.0236 cm
+1 0 0 1 57.02362 729.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.5   Formatting Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 717.0236 cm
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+q
+1 1 1 rg
+n 0 246 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 228 481.2283 -42 re f*
+1 1 1 rg
+n 0 186 481.2283 -126 re f*
+.878431 .878431 .878431 rg
+n 0 60 481.2283 -30 re f*
+1 1 1 rg
+n 0 30 481.2283 -30 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 231 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
+Q
+Q
+q
+1 0 0 1 246.6142 231 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
+Q
+Q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 213 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--section-header-depth=N) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 189 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Sections up to this depth will be used in the header) Tj T* (and footer's replacement of ) Tj /F5 10 Tf (###Section###) Tj /F1 10 Tf (.) Tj T* (Default: ) Tj /F5 10 Tf (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 171 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--smart-quotes=VALUE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 159 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Convert ASCII quotes, ellipses, and dashes to) Tj T* (typographically correct equivalents. Default: ) Tj /F5 10 Tf (0) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 147 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Accepted values:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 141 cm
+Q
+q
+1 0 0 1 246.6142 141 cm
+Q
+q
+1 0 0 1 246.6142 129 cm
 q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 6 14.8 cm
+1 0 0 1 6 -3 cm
 q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
 q
-1 0 0 1 0 0 cm
+1 0 0 1 23 -3 cm
 q
-1 0 0 1 .1 .1 cm
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (0) Tj /F1 10 Tf (: Suppress all transformations.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 246.6142 123 cm
+Q
+q
+1 0 0 1 246.6142 99 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 10.16354 Tw 12 TL /F5 10 Tf 0 0 0 rg (1) Tj /F1 10 Tf (: Default transformations for quotes,) Tj T* 0 Tw (em-dashes, and ellipses.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 246.6142 93 cm
+Q
+q
+1 0 0 1 246.6142 81 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (2) Tj /F1 10 Tf (: Use typewriter shorthand for dashes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 246.6142 75 cm
+Q
+q
+1 0 0 1 246.6142 63 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (3) Tj /F1 10 Tf (: Invert shorthand for dashes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 246.6142 63 cm
+Q
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--fit-literal-mode=MODE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 33 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Handle literals that are too wide. Options: ) Tj /F5 10 Tf (error) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (overflow) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (shrink) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (truncate) Tj /F1 10 Tf (. Default: ) Tj /F5 10 Tf (shrink) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--fit-background-mode=MODE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fit the background image to the page. Options:) Tj T* /F5 10 Tf (scale) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (scale_width) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (center) Tj /F1 10 Tf (. Default: ) Tj /F5 10 Tf (center) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 228 m 481.2283 228 l S
+n 0 186 m 481.2283 186 l S
+n 0 60 m 481.2283 60 l S
+n 0 30 m 481.2283 30 l S
+n 240.6142 0 m 240.6142 246 l S
+n 0 246 m 481.2283 246 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 246 l S
+n 481.2283 0 m 481.2283 246 l S
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+Q
+q
+1 0 0 1 57.02362 441.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (2.6   Miscellaneous Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 429.0236 cm
+Q
+q
+1 0 0 1 57.02362 183.0236 cm
+q
+1 1 1 rg
+n 0 246 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 228 481.2283 -30 re f*
+1 1 1 rg
+n 0 198 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 180 481.2283 -18 re f*
+1 1 1 rg
+n 0 162 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 144 481.2283 -18 re f*
+1 1 1 rg
+n 0 126 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 108 481.2283 -18 re f*
+1 1 1 rg
+n 0 90 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 60 481.2283 -42 re f*
+1 1 1 rg
+n 0 18 481.2283 -18 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 231 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 98.19709 0 Td (Option) Tj T* -98.19709 0 Td ET
+Q
+Q
+q
+1 0 0 1 246.6142 231 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 86.80209 0 Td (Description) Tj T* -86.80209 0 Td ET
+Q
+Q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 201 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (-e) Tj ( ) Tj (EXTENSIONS,) Tj ( ) Tj (--extension-module=EXTE) Tj  T* (NSIONS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 201 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Add a helper extension module \(must end in ) Tj /F5 10 Tf (.py) Tj /F1 10 Tf  T* (and be on the Python path\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 183 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--inline-links) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 183 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Show targets in parentheses instead of active links.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 165 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--repeat-table-rows) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 165 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Repeat the header row for each split table.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 147 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--raw-html) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 147 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Support embedding raw HTML. Default: ) Tj /F5 10 Tf (False) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 129 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--no-footnote-backlinks) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 129 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Disable footnote backlinks. Default: ) Tj /F5 10 Tf (False) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 111 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--inline-footnotes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 111 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Show footnotes inline. Default: ) Tj /F5 10 Tf (True) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 93 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--default-dpi=NUMBER) Tj T* ET
+Q
+Q
+q
+1 0 0 1 246.6142 93 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (DPI for objects sized in pixels. Default: ) Tj /F5 10 Tf (300) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 75 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--show-frame-boundary) Tj T* ET
 Q
 Q
-Q
-Q
-Q
 q
-1 0 0 1 246.6142 3 cm
+1 0 0 1 246.6142 63 cm
 q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 2.439029 Tw (Show frame borders \(only useful for debugging\).) Tj T* 0 Tw (Default=False) Tj T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Show frame borders \(useful for debugging\).) Tj T* (Default: ) Tj /F5 10 Tf (False) Tj /F1 10 Tf (.) Tj T* ET
 Q
 Q
 q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 681.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 26.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
+1 0 0 1 6 45 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--disable-splittables) Tj T* ET
 Q
 Q
-Q
-Q
-Q
 q
-1 0 0 1 246.6142 3 cm
+1 0 0 1 246.6142 21 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 2.677362 Tw (Don't use splittable flowables in some elements.) Tj T* 0 Tw 1.53713 Tw (Only try this if you can't process a document any) Tj T* 0 Tw (other way.) Tj T* ET
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Disable splittable flowables in some elements.) Tj T* (Useful if a document cannot otherwise be) Tj T* (processed.) Tj T* ET
 Q
 Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 654.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-b LEVEL, --break-level=LEVEL) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 1.621772 Tw (Maximum section level that starts in a new page.) Tj T* 0 Tw (Default: 0) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 638.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (--first-page-on-right When using double sided pages, the first page will start) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 623.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (on the right hand side. \(Book Style\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 607.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
 q
 1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--blank-first-page) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL -0.047314 Tw (Add a blank page at the beginning of the document.) Tj T* 0 Tw ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 556.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 38.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--break-side=VALUE) Tj T* ET
 Q
 Q
-Q
-Q
-Q
 q
 1 0 0 1 246.6142 3 cm
 q
-0 0 0 rg
-BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL 3.69631 Tw (How section breaks work. Can be "even", and) Tj T* 0 Tw 1.072025 Tw (sections start in an even page,"odd", and sections) Tj T* 0 Tw .028417 Tw (start in odd pages, or "any" and sections start in the) Tj T* 0 Tw (next page,be it even or odd. See also the -b option.) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Section break behavior. Options: ) Tj /F5 10 Tf (even) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (odd) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (any) Tj /F1 10 Tf (.) Tj T* ET
 Q
 Q
 q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 228 m 481.2283 228 l S
+n 0 198 m 481.2283 198 l S
+n 0 180 m 481.2283 180 l S
+n 0 162 m 481.2283 162 l S
+n 0 144 m 481.2283 144 l S
+n 0 126 m 481.2283 126 l S
+n 0 108 m 481.2283 108 l S
+n 0 90 m 481.2283 90 l S
+n 0 60 m 481.2283 60 l S
+n 0 18 m 481.2283 18 l S
+n 240.6142 0 m 240.6142 246 l S
+n 0 246 m 481.2283 246 l S
+n 0 0 m 481.2283 0 l S
+n 0 0 m 0 246 l S
+n 481.2283 0 m 481.2283 246 l S
 Q
 Q
 Q
 q
-1 0 0 1 57.02362 517.8236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 26.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--date-invariant) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 2.979272 Tw (Don't store the current date in the PDF. Useful) Tj T* 0 Tw 1.412686 Tw (mainly for the test suite, where we don't want the) Tj T* 0 Tw (PDFs to change.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 502.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (-e EXTENSIONS) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Alias for --extension-module) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 463.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 26.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--extension-module=EXTENSIONS) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .298022 Tw (Add a helper extension module to this invocation of) Tj T* 0 Tw 2.734908 Tw (rst2pdf \(module must end in .py and be on the) Tj T* 0 Tw (python path\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 436.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--custom-cover=FILE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 3.359168 Tw (Template file used for the cover page. Default:) Tj T* 0 Tw (cover.tmpl) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 409.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--use-floating-images) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 1.142025 Tw (Makes images with :align: attribute work more like) Tj T* 0 Tw (in rst2html. Default: False) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 370.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 26.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--use-numbered-links) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .492362 Tw (When using numbered sections, adds the numbers) Tj T* 0 Tw .439272 Tw (to all links referring to the section headers. Default:) Tj T* 0 Tw (False) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 343.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 14.8 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--strip-elements-with-class=CLASS) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .10631 Tw (Remove elements with this CLASS from the output.) Tj T* 0 Tw (Can be used multiple times.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 328.4236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 .1 .1 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (--record-dependencies=FILE) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 246.6142 3.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Write output file dependencies to FILE.) Tj T* ET
-Q
-Q
-q
-Q
-Q
+1 0 0 1 57.02362 183.0236 cm
 Q
 q
-1 0 0 1 57.02362 328.4236 cm
+1 0 0 1 57.02362 183.0236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -5740,7 +5183,7 @@ q
 1 0 0 1 104.6457 3 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 85.2785 0 Td (2   Command line options) Tj T* -85.2785 0 Td ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 88.3335 0 Td (2.5   Formatting Options) Tj T* -88.3335 0 Td ET
 Q
 Q
 q
@@ -5758,9 +5201,9 @@ Q
  
 endstream
 endobj
-338 0 obj
+325 0 obj
 <<
-/Length 9763
+/Length 8123
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -5773,237 +5216,384 @@ Q
 q
 1 0 0 1 57.02362 696.0236 cm
 q
+BT 1 0 0 1 0 14 Tm -0.115444 Tw 12 TL /F1 10 Tf 0 0 0 rg (The configuration file uses an ) Tj /F4 10 Tf (INI-style) Tj /F1 10 Tf ( format with sections and key-value pairs. Comments are prefixed with) Tj T* 0 Tw /F5 10 Tf (#) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
 BT 1 0 0 1 0 14 Tm 2.792739 Tw 12 TL /F1 10 Tf 0 0 0 rg (Since version 0.8, rst2pdf will read \(if it is available\) configuration files in ) Tj /F5 10 Tf (/etc/rst2pdf.conf) Tj /F1 10 Tf ( and) Tj T* 0 Tw /F5 10 Tf (~/.rst2pdf/config) Tj /F1 10 Tf (.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 678.0236 cm
+1 0 0 1 57.02362 648.0236 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The user's file at ) Tj /F5 10 Tf (~/.rst2pdf/config) Tj /F1 10 Tf ( will have priority over the system's at ) Tj /F5 10 Tf (/etc/rst2pdf.conf) Tj /F1 10 Tf ( ) Tj /F1 8 Tf 0 .4 .6 rg 5 Ts (1) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 660.0236 cm
+1 0 0 1 57.02362 618.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (3.1   Configuration Options) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 600.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Here's an example file showing some of the currently available options:) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The table below provides detailed descriptions of the available configuration options.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 62.82362 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 588 re B*
+1 0 0 1 57.02362 594.0236 cm
 Q
 q
-.941176 .972549 1 rg
-n 0 564 426 12 re f*
-.941176 .972549 1 rg
-n 426 564 0 12 re f*
-.941176 .972549 1 rg
-n 0 552 0 12 re f*
-.941176 .972549 1 rg
-n 0 540 54 12 re f*
-.941176 .972549 1 rg
-n 54 540 0 12 re f*
-.941176 .972549 1 rg
-n 0 528 336 12 re f*
-.941176 .972549 1 rg
-n 336 528 0 12 re f*
-.941176 .972549 1 rg
-n 0 516 324 12 re f*
-.941176 .972549 1 rg
-n 324 516 0 12 re f*
-.941176 .972549 1 rg
-n 0 504 0 12 re f*
-.941176 .972549 1 rg
-n 0 492 66 12 re f*
-.941176 .972549 1 rg
-n 66 492 6 12 re f*
-.941176 .972549 1 rg
-n 72 492 12 12 re f*
-.941176 .972549 1 rg
-n 84 492 0 12 re f*
-.941176 .972549 1 rg
-n 0 480 0 12 re f*
-.941176 .972549 1 rg
-n 0 468 150 12 re f*
-.941176 .972549 1 rg
-n 150 468 0 12 re f*
-.941176 .972549 1 rg
-n 0 456 216 12 re f*
-.941176 .972549 1 rg
-n 216 456 0 12 re f*
-.941176 .972549 1 rg
-n 0 444 60 12 re f*
-.941176 .972549 1 rg
-n 60 444 6 12 re f*
-.941176 .972549 1 rg
-n 66 444 30 12 re f*
-.941176 .972549 1 rg
-n 96 444 0 12 re f*
-.941176 .972549 1 rg
-n 0 432 0 12 re f*
-.941176 .972549 1 rg
-n 0 420 390 12 re f*
-.941176 .972549 1 rg
-n 390 420 0 12 re f*
-.941176 .972549 1 rg
-n 0 408 354 12 re f*
-.941176 .972549 1 rg
-n 354 408 0 12 re f*
-.941176 .972549 1 rg
-n 0 396 0 12 re f*
-.941176 .972549 1 rg
-n 0 384 54 12 re f*
-.941176 .972549 1 rg
-n 54 384 6 12 re f*
-.941176 .972549 1 rg
-n 60 384 12 12 re f*
-.941176 .972549 1 rg
-n 72 384 0 12 re f*
-.941176 .972549 1 rg
-n 0 372 0 12 re f*
-.941176 .972549 1 rg
-n 0 360 426 12 re f*
-.941176 .972549 1 rg
-n 426 360 0 12 re f*
-.941176 .972549 1 rg
-n 0 348 276 12 re f*
-.941176 .972549 1 rg
-n 276 348 0 12 re f*
-.941176 .972549 1 rg
-n 0 336 90 12 re f*
-.941176 .972549 1 rg
-n 90 336 6 12 re f*
-.941176 .972549 1 rg
-n 96 336 12 12 re f*
-.941176 .972549 1 rg
-n 108 336 0 12 re f*
-.941176 .972549 1 rg
-n 0 324 0 12 re f*
-.941176 .972549 1 rg
-n 0 312 270 12 re f*
-.941176 .972549 1 rg
-n 270 312 0 12 re f*
-.941176 .972549 1 rg
-n 0 300 0 12 re f*
-.941176 .972549 1 rg
-n 0 288 48 12 re f*
-.941176 .972549 1 rg
-n 48 288 6 12 re f*
-.941176 .972549 1 rg
-n 54 288 42 12 re f*
-.941176 .972549 1 rg
-n 96 288 0 12 re f*
-.941176 .972549 1 rg
-n 0 276 0 12 re f*
-.941176 .972549 1 rg
-n 0 264 192 12 re f*
-.941176 .972549 1 rg
-n 192 264 0 12 re f*
-.941176 .972549 1 rg
-n 0 252 36 12 re f*
-.941176 .972549 1 rg
-n 36 252 6 12 re f*
-.941176 .972549 1 rg
-n 42 252 24 12 re f*
-.941176 .972549 1 rg
-n 66 252 0 12 re f*
-.941176 .972549 1 rg
-n 0 240 36 12 re f*
-.941176 .972549 1 rg
-n 36 240 6 12 re f*
-.941176 .972549 1 rg
-n 42 240 24 12 re f*
-.941176 .972549 1 rg
-n 66 240 0 12 re f*
-.941176 .972549 1 rg
-n 0 228 0 12 re f*
-.941176 .972549 1 rg
-n 0 216 312 12 re f*
-.941176 .972549 1 rg
-n 312 216 0 12 re f*
-.941176 .972549 1 rg
-n 0 204 156 12 re f*
-.941176 .972549 1 rg
-n 156 204 0 12 re f*
-.941176 .972549 1 rg
-n 0 192 0 12 re f*
-.941176 .972549 1 rg
-n 0 180 48 12 re f*
-.941176 .972549 1 rg
-n 48 180 6 12 re f*
-.941176 .972549 1 rg
-n 54 180 48 12 re f*
-.941176 .972549 1 rg
-n 102 180 0 12 re f*
-.941176 .972549 1 rg
-n 0 168 0 12 re f*
-.941176 .972549 1 rg
-n 0 156 294 12 re f*
-.941176 .972549 1 rg
-n 294 156 0 12 re f*
-.941176 .972549 1 rg
-n 0 144 180 12 re f*
-.941176 .972549 1 rg
-n 180 144 0 12 re f*
-.941176 .972549 1 rg
-n 0 132 0 12 re f*
-.941176 .972549 1 rg
-n 0 120 114 12 re f*
-.941176 .972549 1 rg
-n 114 120 6 12 re f*
-.941176 .972549 1 rg
-n 120 120 48 12 re f*
-.941176 .972549 1 rg
-n 168 120 0 12 re f*
-.941176 .972549 1 rg
-n 0 108 0 12 re f*
-.941176 .972549 1 rg
-n 0 96 390 12 re f*
-.941176 .972549 1 rg
-n 390 96 0 12 re f*
-.941176 .972549 1 rg
-n 0 84 240 12 re f*
-.941176 .972549 1 rg
-n 240 84 0 12 re f*
-.941176 .972549 1 rg
-n 0 72 0 12 re f*
-.941176 .972549 1 rg
-n 0 60 66 12 re f*
-.941176 .972549 1 rg
-n 66 60 6 12 re f*
-.941176 .972549 1 rg
-n 72 60 6 12 re f*
-.941176 .972549 1 rg
-n 78 60 0 12 re f*
-.941176 .972549 1 rg
-n 0 48 0 12 re f*
-.941176 .972549 1 rg
-n 0 36 396 12 re f*
-.941176 .972549 1 rg
-n 396 36 0 12 re f*
-.941176 .972549 1 rg
-n 0 24 390 12 re f*
-.941176 .972549 1 rg
-n 390 24 0 12 re f*
-.941176 .972549 1 rg
-n 0 12 318 12 re f*
-.941176 .972549 1 rg
-n 318 12 0 12 re f*
-.941176 .972549 1 rg
-n 0 0 0 12 re f*
-BT 1 0 0 1 0 566 Tm 12 TL /F6 10 Tf .25098 .501961 .501961 rg (# This is an example config file. Modify and place in ~/.rst2pdf/config) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* /F7 10 Tf 0 .501961 0 rg ([general]) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# A comma-separated list of custom stylesheets. Example:) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# stylesheets="fruity.json,a4paper.json,verasans.json") Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (stylesheets) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Create a compressed PDF) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# Use true/false \(lower case\) or 1/0) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (compressed) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# A colon-separated list of folders to search for fonts. Example:) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# font_path="/usr/share/fonts:/usr/share/texmf-dist/fonts/") Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (font_path) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# A colon-separated list of folders to search for stylesheets. Example:) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# stylesheet_path="~/styles:/usr/share/styles") Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (stylesheet_path) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Language to be used for hyphenation support) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (language) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("en_US") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Default page header and footer) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (header) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (null) Tj .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (footer) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (null) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# What to do if a literal block is too large. Can be) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# shrink/truncate/overflow) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (fit_mode) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("shrink") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# How to adjust the background image to the page.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# Can be: "scale" and "center") Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (fit_background_mode) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("center") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# What is the maximum level of heading that starts in a new page.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# 0 means no level starts in a new page.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (break_level) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (0) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# How section breaks work. Can be "even", and sections start in an) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# even page, "odd", and sections start in odd pages, or "any" and) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# sections start in the next page, be it even or odd.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* ET
+1 0 0 1 57.02362 186.0236 cm
+q
+1 1 1 rg
+n 0 408 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 390 481.2283 -30 re f*
+1 1 1 rg
+n 0 360 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 330 481.2283 -30 re f*
+1 1 1 rg
+n 0 300 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 270 481.2283 -30 re f*
+1 1 1 rg
+n 0 240 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 210 481.2283 -30 re f*
+1 1 1 rg
+n 0 180 481.2283 -42 re f*
+.878431 .878431 .878431 rg
+n 0 138 481.2283 -30 re f*
+1 1 1 rg
+n 0 108 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 78 481.2283 -30 re f*
+1 1 1 rg
+n 0 48 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 18 481.2283 -18 re f*
+0 0 0 rg
+BT /F4 10 Tf 12 TL ET
+q
+1 0 0 1 6 393 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 58.09472 0 Td (Option) Tj T* -58.09472 0 Td ET
 Q
 Q
+q
+1 0 0 1 166.4094 393 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 46.69972 0 Td (Description) Tj T* -46.69972 0 Td ET
+Q
+Q
+q
+1 0 0 1 326.8189 393 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL 42.52972 0 Td (Default Value) Tj T* -42.52972 0 Td ET
+Q
+Q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 375 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (stylesheets) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 363 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Comma-separated list of custom) Tj T* (stylesheets.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 375 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL ("") Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 345 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (compressed) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 333 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Generate a compressed PDF.) Tj T* (Use ) Tj /F5 10 Tf (true) Tj /F1 10 Tf (/) Tj /F5 10 Tf (false) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (1) Tj /F1 10 Tf (/) Tj /F5 10 Tf (0) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 345 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 315 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (font_path) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 303 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Colon-separated list of folders to) Tj T* (search for fonts.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 315 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL ("") Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 285 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (stylesheet_path) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 273 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Colon-separated list of folders to) Tj T* (search for stylesheets.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 285 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL ("") Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 255 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (language) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 243 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Language for hyphenation and) Tj T* (localization.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 255 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (en_US) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 225 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (header) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 213 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Default page header. Use ) Tj /F5 10 Tf (null) Tj /F1 10 Tf  T* (for no header.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 225 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (null) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 195 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (footer) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 183 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Default page footer. Use ) Tj /F5 10 Tf (null) Tj /F1 10 Tf  T* (for no footer.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 195 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (null) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 165 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (fit_mode) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 141 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Handle oversized literal blocks.) Tj T* (Options: ) Tj /F5 10 Tf (shrink) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (truncate) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (overflow) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 165 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (shrink) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 123 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (fit_background_mode) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 111 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Adjust background images.) Tj T* (Options: ) Tj /F5 10 Tf (scale) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (center) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 123 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (center) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 93 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (break_level) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Maximum heading level that) Tj T* (starts on a new page.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 93 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (break_side) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 51 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Section break alignment.) Tj T* (Options: ) Tj /F5 10 Tf (even) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (odd) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (any) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (any) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (blank_first_page) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Add a blank page at the start of) Tj T* (the document.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (first_page_even) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Treat the first page as even.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 0 m 481.2283 0 l S
+n 0 390 m 481.2283 390 l S
+n 0 360 m 481.2283 360 l S
+n 0 330 m 481.2283 330 l S
+n 0 300 m 481.2283 300 l S
+n 0 270 m 481.2283 270 l S
+n 0 240 m 481.2283 240 l S
+n 0 210 m 481.2283 210 l S
+n 0 180 m 481.2283 180 l S
+n 0 138 m 481.2283 138 l S
+n 0 108 m 481.2283 108 l S
+n 0 78 m 481.2283 78 l S
+n 0 48 m 481.2283 48 l S
+n 0 18 m 481.2283 18 l S
+n 160.4094 0 m 160.4094 408 l S
+n 320.8189 0 m 320.8189 408 l S
+n 0 408 m 481.2283 408 l S
+n 0 0 m 0 408 l S
+n 481.2283 0 m 481.2283 408 l S
 Q
 Q
 Q
@@ -6050,216 +5640,370 @@ Q
  
 endstream
 endobj
-339 0 obj
+326 0 obj
 <<
-/Length 8484
+/Length 7041
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
-1 0 0 1 57.02362 248.8506 cm
+1 0 0 1 57.02362 459.0236 cm
+q
+1 1 1 rg
+n 0 288 481.2283 -174 re f*
+.878431 .878431 .878431 rg
+n 0 114 481.2283 -18 re f*
+1 1 1 rg
+n 0 96 481.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 78 481.2283 -18 re f*
+1 1 1 rg
+n 0 60 481.2283 -30 re f*
+.878431 .878431 .878431 rg
+n 0 30 481.2283 -30 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 273 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (smartquotes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 261 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Configure smart quotes) Tj T* (transformation.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 249 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Accepted values:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 243 cm
+Q
+q
+1 0 0 1 166.4094 243 cm
+Q
+q
+1 0 0 1 166.4094 219 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 29.41472 Tw 12 TL /F5 10 Tf 0 0 0 rg (0) Tj /F1 10 Tf (: Suppress all) Tj T* 0 Tw (transformations.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 166.4094 213 cm
+Q
+q
+1 0 0 1 166.4094 177 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 5.239724 Tw 12 TL /F5 10 Tf 0 0 0 rg (1) Tj /F1 10 Tf (: Default transformations) Tj T* 0 Tw 1.226483 Tw (for quotes, em-dashes, and) Tj T* 0 Tw (ellipses.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 166.4094 171 cm
+Q
+q
+1 0 0 1 166.4094 147 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm .899816 Tw 12 TL /F5 10 Tf 0 0 0 rg (2) Tj /F1 10 Tf (: Use typewriter shorthand) Tj T* 0 Tw (for dashes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 166.4094 141 cm
+Q
+q
+1 0 0 1 166.4094 117 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 9.046483 Tw 12 TL /F5 10 Tf 0 0 0 rg (3) Tj /F1 10 Tf (: Invert shorthand for) Tj T* 0 Tw (dashes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 166.4094 117 cm
+Q
+q
+1 0 0 1 326.8189 273 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 99 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (footnote_backlinks) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 99 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Enable footnote backlinks.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 99 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (true) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (inline_footnotes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Show footnotes inline.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (custom_cover) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Template file for the cover page.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 63 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (cover.tmpl) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (floating_images) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Enable floating images for) Tj T* (alignment.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (raw_html) Tj T* ET
+Q
+Q
+q
+1 0 0 1 166.4094 3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Enable support for the) Tj T* /F5 10 Tf (..raw::) Tj ( ) Tj (html) Tj /F1 10 Tf ( directive.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 326.8189 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (false) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 288 m 481.2283 288 l S
+n 0 114 m 481.2283 114 l S
+n 0 96 m 481.2283 96 l S
+n 0 78 m 481.2283 78 l S
+n 0 60 m 481.2283 60 l S
+n 0 30 m 481.2283 30 l S
+n 160.4094 0 m 160.4094 288 l S
+n 320.8189 0 m 320.8189 288 l S
+n 0 0 m 0 288 l S
+n 481.2283 0 m 481.2283 288 l S
+n 0 0 m 481.2283 0 l S
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 459.0236 cm
+Q
+q
+1 0 0 1 57.02362 429.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (3.2   Example Configuration File) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 411.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Here's an example configuration file showing the expected format:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 269.8236 cm
 q
 q
-.94137 0 0 .94137 0 0 cm
+1 0 0 1 0 0 cm
 q
-1 0 0 1 6.6 7.011058 cm
+1 0 0 1 6.6 6.6 cm
 q
 .662745 .662745 .662745 RG
 .5 w
 .941176 .972549 1 rg
-n -6 -6 510 528 re B*
+n -6 -6 480.0283 132 re B*
 Q
 q
 .941176 .972549 1 rg
-n 0 504 60 12 re f*
+n 0 108 426 12 re f*
 .941176 .972549 1 rg
-n 60 504 6 12 re f*
+n 426 108 0 12 re f*
 .941176 .972549 1 rg
-n 66 504 30 12 re f*
+n 0 96 0 12 re f*
 .941176 .972549 1 rg
-n 96 504 0 12 re f*
+n 0 84 54 12 re f*
 .941176 .972549 1 rg
-n 0 492 0 12 re f*
+n 54 84 0 12 re f*
 .941176 .972549 1 rg
-n 0 480 306 12 re f*
+n 0 72 66 12 re f*
 .941176 .972549 1 rg
-n 306 480 0 12 re f*
+n 66 72 6 12 re f*
 .941176 .972549 1 rg
-n 0 468 0 12 re f*
+n 72 72 240 12 re f*
 .941176 .972549 1 rg
-n 0 456 96 12 re f*
+n 312 72 0 12 re f*
 .941176 .972549 1 rg
-n 96 456 6 12 re f*
+n 0 60 0 12 re f*
 .941176 .972549 1 rg
-n 102 456 30 12 re f*
+n 0 48 216 12 re f*
 .941176 .972549 1 rg
-n 132 456 0 12 re f*
-.941176 .972549 1 rg
-n 0 444 0 12 re f*
-.941176 .972549 1 rg
-n 0 432 378 12 re f*
-.941176 .972549 1 rg
-n 378 432 0 12 re f*
-.941176 .972549 1 rg
-n 0 420 0 12 re f*
-.941176 .972549 1 rg
-n 0 408 90 12 re f*
-.941176 .972549 1 rg
-n 90 408 6 12 re f*
-.941176 .972549 1 rg
-n 96 408 30 12 re f*
-.941176 .972549 1 rg
-n 126 408 0 12 re f*
-.941176 .972549 1 rg
-n 0 396 0 12 re f*
-.941176 .972549 1 rg
-n 0 384 90 12 re f*
-.941176 .972549 1 rg
-n 90 384 0 12 re f*
-.941176 .972549 1 rg
-n 0 372 306 12 re f*
-.941176 .972549 1 rg
-n 306 372 0 12 re f*
-.941176 .972549 1 rg
-n 0 360 492 12 re f*
-.941176 .972549 1 rg
-n 492 360 0 12 re f*
-.941176 .972549 1 rg
-n 0 348 498 12 re f*
-.941176 .972549 1 rg
-n 498 348 0 12 re f*
-.941176 .972549 1 rg
-n 0 336 216 12 re f*
-.941176 .972549 1 rg
-n 216 336 0 12 re f*
-.941176 .972549 1 rg
-n 0 324 456 12 re f*
-.941176 .972549 1 rg
-n 456 324 0 12 re f*
-.941176 .972549 1 rg
-n 0 312 474 12 re f*
-.941176 .972549 1 rg
-n 474 312 0 12 re f*
-.941176 .972549 1 rg
-n 0 300 444 12 re f*
-.941176 .972549 1 rg
-n 444 300 0 12 re f*
-.941176 .972549 1 rg
-n 0 288 330 12 re f*
-.941176 .972549 1 rg
-n 330 288 0 12 re f*
-.941176 .972549 1 rg
-n 0 276 0 12 re f*
-.941176 .972549 1 rg
-n 0 264 66 12 re f*
-.941176 .972549 1 rg
-n 66 264 6 12 re f*
-.941176 .972549 1 rg
-n 72 264 6 12 re f*
-.941176 .972549 1 rg
-n 78 264 0 12 re f*
-.941176 .972549 1 rg
-n 0 252 0 12 re f*
-.941176 .972549 1 rg
-n 0 240 324 12 re f*
-.941176 .972549 1 rg
-n 324 240 0 12 re f*
-.941176 .972549 1 rg
-n 0 228 0 12 re f*
-.941176 .972549 1 rg
-n 0 216 108 12 re f*
-.941176 .972549 1 rg
-n 108 216 6 12 re f*
-.941176 .972549 1 rg
-n 114 216 24 12 re f*
-.941176 .972549 1 rg
-n 138 216 0 12 re f*
-.941176 .972549 1 rg
-n 0 204 0 12 re f*
-.941176 .972549 1 rg
-n 0 192 366 12 re f*
-.941176 .972549 1 rg
-n 366 192 0 12 re f*
-.941176 .972549 1 rg
-n 0 180 0 12 re f*
-.941176 .972549 1 rg
-n 0 168 96 12 re f*
-.941176 .972549 1 rg
-n 96 168 6 12 re f*
-.941176 .972549 1 rg
-n 102 168 30 12 re f*
-.941176 .972549 1 rg
-n 132 168 0 12 re f*
-.941176 .972549 1 rg
-n 0 156 0 12 re f*
-.941176 .972549 1 rg
-n 0 144 132 12 re f*
-.941176 .972549 1 rg
-n 132 144 0 12 re f*
-.941176 .972549 1 rg
-n 0 132 450 12 re f*
-.941176 .972549 1 rg
-n 450 132 0 12 re f*
-.941176 .972549 1 rg
-n 0 120 300 12 re f*
-.941176 .972549 1 rg
-n 300 120 0 12 re f*
-.941176 .972549 1 rg
-n 0 108 0 12 re f*
-.941176 .972549 1 rg
-n 0 96 162 12 re f*
-.941176 .972549 1 rg
-n 162 96 0 12 re f*
-.941176 .972549 1 rg
-n 0 84 0 12 re f*
-.941176 .972549 1 rg
-n 0 72 132 12 re f*
-.941176 .972549 1 rg
-n 132 72 0 12 re f*
-.941176 .972549 1 rg
-n 0 60 474 12 re f*
-.941176 .972549 1 rg
-n 474 60 0 12 re f*
-.941176 .972549 1 rg
-n 0 48 0 12 re f*
+n 216 48 0 12 re f*
 .941176 .972549 1 rg
 n 0 36 90 12 re f*
 .941176 .972549 1 rg
 n 90 36 6 12 re f*
 .941176 .972549 1 rg
-n 96 36 6 12 re f*
+n 96 36 168 12 re f*
 .941176 .972549 1 rg
-n 102 36 6 12 re f*
-.941176 .972549 1 rg
-n 108 36 30 12 re f*
-.941176 .972549 1 rg
-n 138 36 0 12 re f*
+n 264 36 0 12 re f*
 .941176 .972549 1 rg
 n 0 24 0 12 re f*
 .941176 .972549 1 rg
-n 0 12 216 12 re f*
+n 0 12 270 12 re f*
 .941176 .972549 1 rg
-n 216 12 0 12 re f*
+n 270 12 0 12 re f*
 .941176 .972549 1 rg
 n 0 0 48 12 re f*
 .941176 .972549 1 rg
 n 48 0 6 12 re f*
 .941176 .972549 1 rg
-n 54 0 6 12 re f*
-.941176 .972549 1 rg
-n 60 0 6 12 re f*
-.941176 .972549 1 rg
-n 66 0 30 12 re f*
+n 54 0 42 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 506 Tm 12 TL /F5 10 Tf .490196 .564706 .160784 rg (break_side) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("any") Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Add a blank page at the beginning of the document) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (blank_first_page) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Treat the first page as even \(default false, treat it as odd\)) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (first_page_even) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Smart quotes.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# 0:  Suppress  all  transformations. \(Do nothing.\)) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# 1: Performs default SmartyPants transformations: quotes \(including \221\221backticks'') Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# -style\), em-dashes, and ellipses. "--" \(dash dash\) is used to signify an em-dash;) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# there is no support for en-dashes.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# 2:  Same as 1, except that it uses the old-school typewriter shorthand for) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# dashes: "--" \(dash dash\) for en-dashes, "---" \(dash dash dash\) for em-dashes.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# 3: Same as 2, but inverts the shorthand for dashes: "--" \(dash dash\) for) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# em-dashes,  and "---" \(dash dash dash\) for en-dashes.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (smartquotes) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (0) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Footnote backlinks enabled or not \(default: enabled\)) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (footnote_backlinks) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (true) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Show footnotes inline instead of at the end of the document) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (inline_footnotes) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Cover page template.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# It will be searched in the document's folder, in ~/.rst2pdf/templates and) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# in the templates subfolder of the package folder) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# custom_cover = cover.tmpl) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Use floating images.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* /F6 10 Tf .25098 .501961 .501961 rg (# Makes the behaviour of images with the :align: attribute more like rst2html's) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* .490196 .564706 .160784 rg (floating_images) Tj .733333 .733333 .733333 rg ( ) Tj .4 .4 .4 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T*  T* /F6 10 Tf .25098 .501961 .501961 rg (# Support the ..raw:: html directive) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (raw_html) Tj .733333 .733333 .733333 rg ( ) Tj .4 .4 .4 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg (false) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 110 Tm 12 TL /F7 10 Tf .25098 .501961 .501961 rg (# This is an example config file. Modify and place in ~/.rst2pdf/config) Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* /F8 10 Tf 0 .501961 0 rg ([general]) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (stylesheets) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("fruity.json,a4paper.json,verasans.json") Tj .733333 .733333 .733333 rg  T*  T* /F7 10 Tf .25098 .501961 .501961 rg (# Folders to search for stylesheets.) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (stylesheet_path) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("~/styles:/usr/share/styles") Tj .733333 .733333 .733333 rg  T*  T* /F7 10 Tf .25098 .501961 .501961 rg (# Language to be used for hyphenation support) Tj /F5 10 Tf .733333 .733333 .733333 rg  T* .490196 .564706 .160784 rg (language) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("en_US") Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
 Q
 Q
 q
-1 0 0 1 57.02362 240.8506 cm
+1 0 0 1 57.02362 261.8236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -6287,7 +6031,7 @@ q
 1 0 0 1 104.6457 3 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 95.8385 0 Td (3   Configuration File) Tj T* -95.8385 0 Td ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 70.8285 0 Td (3.2   Example Configuration File) Tj T* -70.8285 0 Td ET
 Q
 Q
 q
@@ -6305,7 +6049,7 @@ Q
  
 endstream
 endobj
-340 0 obj
+327 0 obj
 <<
 /Length 2647
 >>
@@ -6476,7 +6220,7 @@ Q
  
 endstream
 endobj
-341 0 obj
+328 0 obj
 <<
 /Length 5365
 >>
@@ -6730,7 +6474,7 @@ Q
  
 endstream
 endobj
-342 0 obj
+329 0 obj
 <<
 /Length 6343
 >>
@@ -7091,7 +6835,7 @@ Q
  
 endstream
 endobj
-343 0 obj
+330 0 obj
 <<
 /Length 5176
 >>
@@ -7288,7 +7032,7 @@ Q
  
 endstream
 endobj
-344 0 obj
+331 0 obj
 <<
 /Length 4514
 >>
@@ -7443,13 +7187,13 @@ Q
 q
 1 0 0 1 57.02362 456.8236 cm
 q
-BT 1 0 0 1 0 14 Tm .156962 Tw 12 TL /F1 10 Tf 0 0 0 rg (Headers and footers are visible by default but they can be disabled by specific ) Tj 0 .4 .6 rg (Page Templates) Tj 0 0 0 rg ( for example,) Tj T* 0 Tw (cover pages. You can also set headers and footers via ) Tj /F8 10 Tf (command line options) Tj /F1 10 Tf ( or the ) Tj 0 .4 .6 rg (configuration file) Tj 0 0 0 rg (.) Tj T* ET
+BT 1 0 0 1 0 14 Tm .156962 Tw 12 TL /F1 10 Tf 0 0 0 rg (Headers and footers are visible by default but they can be disabled by specific ) Tj 0 .4 .6 rg (Page Templates) Tj 0 0 0 rg ( for example,) Tj T* 0 Tw (cover pages. You can also set headers and footers via ) Tj /F6 10 Tf (command line options) Tj /F1 10 Tf ( or the ) Tj 0 .4 .6 rg (configuration file) Tj 0 0 0 rg (.) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 438.8236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (If you want to do things like "put the page number on the ) Tj /F8 10 Tf (out) Tj /F1 10 Tf ( side of the page, check ) Tj 0 .4 .6 rg (The oddeven directive) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (If you want to do things like "put the page number on the ) Tj /F6 10 Tf (out) Tj /F1 10 Tf ( side of the page, check ) Tj 0 .4 .6 rg (The oddeven directive) Tj T* ET
 Q
 Q
 q
@@ -7517,7 +7261,7 @@ Q
  
 endstream
 endobj
-345 0 obj
+332 0 obj
 <<
 /Length 8899
 >>
@@ -7639,7 +7383,7 @@ Q
 q
 1 0 0 1 57.02362 606.0236 cm
 q
-BT 1 0 0 1 0 26 Tm 1.172844 Tw 12 TL /F1 10 Tf 0 0 0 rg (The stylesheets use a YAML format \(JSON is also supported\). Older versions of this tool used an RSON) Tj T* 0 Tw .224609 Tw (format; this is also still supported but we recommend you check the section on ) Tj /F8 10 Tf (migrating to yaml stylesheets) Tj /F1 10 Tf  T* 0 Tw (and update them \(it's painless!\)) Tj T* ET
+BT 1 0 0 1 0 26 Tm 1.172844 Tw 12 TL /F1 10 Tf 0 0 0 rg (The stylesheets use a YAML format \(JSON is also supported\). Older versions of this tool used an RSON) Tj T* 0 Tw .224609 Tw (format; this is also still supported but we recommend you check the section on ) Tj /F6 10 Tf (migrating to yaml stylesheets) Tj /F1 10 Tf  T* 0 Tw (and update them \(it's painless!\)) Tj T* ET
 Q
 Q
 q
@@ -8144,7 +7888,7 @@ Q
  
 endstream
 endobj
-346 0 obj
+333 0 obj
 <<
 /Length 7088
 >>
@@ -8476,7 +8220,7 @@ Q
  
 endstream
 endobj
-347 0 obj
+334 0 obj
 <<
 /Length 7676
 >>
@@ -8968,7 +8712,7 @@ Q
  
 endstream
 endobj
-348 0 obj
+335 0 obj
 <<
 /Length 9183
 >>
@@ -9070,7 +8814,7 @@ n 78 0 6 12 re f*
 n 84 0 12 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 74 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (pageSetup) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (size) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (A5) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (fontsAlias) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (fontSerif) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Times-Roman) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (normal) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (14) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 74 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (pageSetup) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (size) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (A5) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (fontsAlias) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (fontSerif) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Times-Roman) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (normal) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (14) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9112,7 +8856,7 @@ Q
 q
 1 0 0 1 57.02362 447.6236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Most of the other elements for colours and formatting are in the ) Tj /F8 10 Tf (styles) Tj /F1 10 Tf ( section.) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Most of the other elements for colours and formatting are in the ) Tj /F6 10 Tf (styles) Tj /F1 10 Tf ( section.) Tj T* ET
 Q
 Q
 q
@@ -9167,7 +8911,7 @@ n 78 0 6 12 re f*
 n 84 0 12 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 26 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (base) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (12) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 26 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (base) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (12) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9235,7 +8979,7 @@ n 96 0 6 12 re f*
 n 102 0 42 12 re f*
 .941176 .972549 1 rg
 n 144 0 0 12 re f*
-BT 1 0 0 1 0 26 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* ( ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj /F7 10 Tf 0 .501961 0 rg (bodytext) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (      ) Tj /F7 10 Tf 0 .501961 0 rg (alignment) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (TA_LEFT) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 26 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (styles) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* ( ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj /F8 10 Tf 0 .501961 0 rg (bodytext) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (      ) Tj /F8 10 Tf 0 .501961 0 rg (alignment) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (TA_LEFT) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9308,7 +9052,7 @@ Q
  
 endstream
 endobj
-349 0 obj
+336 0 obj
 <<
 /Length 8045
 >>
@@ -9378,7 +9122,7 @@ n 54 0 6 12 re f*
 n 60 0 42 12 re f*
 .941176 .972549 1 rg
 n 102 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (code) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (parent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (literal) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (code) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (parent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (literal) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9429,7 +9173,7 @@ n 54 0 6 12 re f*
 n 60 0 54 12 re f*
 .941176 .972549 1 rg
 n 114 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (fontName) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Helvetica) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (fontName) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Helvetica) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9561,7 +9305,7 @@ n 54 0 6 12 re f*
 n 60 0 24 12 re f*
 .941176 .972549 1 rg
 n 84 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (150%) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (fontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (150%) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9614,7 +9358,7 @@ n 72 0 6 12 re f*
 n 78 0 6 12 re f*
 .941176 .972549 1 rg
 n 84 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (leftIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (rightIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (leftIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (rightIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9658,7 +9402,7 @@ n 96 0 6 12 re f*
 n 102 0 6 12 re f*
 .941176 .972549 1 rg
 n 108 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (firstLineIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (firstLineIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9708,7 +9452,7 @@ n 60 0 6 12 re f*
 n 66 0 42 12 re f*
 .941176 .972549 1 rg
 n 108 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (alignment) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (TA_LEFT) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (alignment) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (TA_LEFT) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9758,7 +9502,7 @@ Q
  
 endstream
 endobj
-350 0 obj
+337 0 obj
 <<
 /Length 9235
 >>
@@ -9817,7 +9561,7 @@ n 66 0 6 12 re f*
 n 72 0 6 12 re f*
 .941176 .972549 1 rg
 n 78 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (spaceBefore) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (4) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (spaceAfter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (8) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (spaceBefore) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (4) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (spaceAfter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (8) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -9832,7 +9576,7 @@ Q
 q
 1 0 0 1 57.02362 579.8236 cm
 q
-BT 1 0 0 1 0 26 Tm .199387 Tw 12 TL /F1 10 Tf 0 0 0 rg (The bullets can be complex to style, but there are some tricks that might help. The vertical space before and) Tj T* 0 Tw .07789 Tw (after the list and item elements are controlled by the ) Tj /F5 10 Tf (spaceBefore) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (spaceAfter) Tj /F1 10 Tf ( properties. Also these) Tj T* 0 Tw (lists are ) Tj /F8 10 Tf (tables) Tj /F1 10 Tf ( so those styles also apply.) Tj T* ET
+BT 1 0 0 1 0 26 Tm .199387 Tw 12 TL /F1 10 Tf 0 0 0 rg (The bullets can be complex to style, but there are some tricks that might help. The vertical space before and) Tj T* 0 Tw .07789 Tw (after the list and item elements are controlled by the ) Tj /F5 10 Tf (spaceBefore) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (spaceAfter) Tj /F1 10 Tf ( properties. Also these) Tj T* 0 Tw (lists are ) Tj /F6 10 Tf (tables) Tj /F1 10 Tf ( so those styles also apply.) Tj T* ET
 Q
 Q
 q
@@ -9900,7 +9644,7 @@ n 78 0 6 12 re f*
 n 84 0 6 12 re f*
 .941176 .972549 1 rg
 n 90 0 0 12 re f*
-BT 1 0 0 1 0 38 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (bulletFontName) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Helvetica) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (bulletFontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (10) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (bulletText) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg (") Tj /F7 10 Tf .733333 .4 .133333 rg (\\u2022) Tj /F5 10 Tf .729412 .129412 .129412 rg (") Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (bulletIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 38 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (bulletFontName) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (Helvetica) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (bulletFontSize) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (10) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (bulletText) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg (") Tj /F8 10 Tf .733333 .4 .133333 rg (\\u2022) Tj /F5 10 Tf .729412 .129412 .129412 rg (") Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (bulletIndent) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10005,7 +9749,7 @@ n 60 0 6 12 re f*
 n 66 0 30 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (textColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (black) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (textColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (black) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10055,7 +9799,7 @@ n 60 0 6 12 re f*
 n 66 0 30 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (backColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (beige) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (backColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (beige) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10105,7 +9849,7 @@ n 54 0 6 12 re f*
 n 60 0 24 12 re f*
 .941176 .972549 1 rg
 n 84 0 0 12 re f*
-BT 1 0 0 1 0 2 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (wordWrap) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (None) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (wordWrap) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (None) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10165,7 +9909,7 @@ n 84 0 6 12 re f*
 n 90 0 6 12 re f*
 .941176 .972549 1 rg
 n 96 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (borderColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (darkgray) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (borderPadding) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (6) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (borderColor) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (darkgray) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (borderPadding) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (6) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10214,7 +9958,7 @@ Q
  
 endstream
 endobj
-351 0 obj
+338 0 obj
 <<
 /Length 8714
 >>
@@ -10254,7 +9998,7 @@ n 78 0 6 12 re f*
 n 84 0 24 12 re f*
 .941176 .972549 1 rg
 n 108 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (borderWidth) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0.5) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (borderRadius) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (None) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (borderWidth) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0.5) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (borderRadius) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (None) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10314,7 +10058,7 @@ n 78 0 6 12 re f*
 n 84 0 6 12 re f*
 .941176 .972549 1 rg
 n 90 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (allowWidows) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (5) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (allowOrphans) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (4) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (allowWidows) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (5) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (allowOrphans) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (4) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10442,7 +10186,7 @@ n 84 0 6 12 re f*
 n 90 0 18 12 re f*
 .941176 .972549 1 rg
 n 108 0 0 12 re f*
-BT 1 0 0 1 0 50 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (margin-top) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (margin-bottom) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (margin-left) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (margin-right) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 .501961 0 rg (margin-gutter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0cm) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 50 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (margin-top) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (margin-bottom) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (margin-left) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (margin-right) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (2cm) Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 .501961 0 rg (margin-gutter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (0cm) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -10655,7 +10399,7 @@ Q
  
 endstream
 endobj
-352 0 obj
+339 0 obj
 <<
 /Length 5199
 >>
@@ -10857,7 +10601,7 @@ Q
  
 endstream
 endobj
-353 0 obj
+340 0 obj
 <<
 /Length 11928
 >>
@@ -10907,7 +10651,7 @@ Q
 q
 1 0 0 1 57.02362 602.8236 cm
 q
-BT 1 0 0 1 0 14 Tm .51713 Tw 12 TL /F1 10 Tf 0 0 0 rg (To do it, you need to define ) Tj /F8 10 Tf (Page Templates) Tj /F1 10 Tf ( in your stylesheet. The default stylesheet already has three of) Tj T* 0 Tw (them:) Tj T* ET
+BT 1 0 0 1 0 14 Tm .51713 Tw 12 TL /F1 10 Tf 0 0 0 rg (To do it, you need to define ) Tj /F6 10 Tf (Page Templates) Tj /F1 10 Tf ( in your stylesheet. The default stylesheet already has three of) Tj T* 0 Tw (them:) Tj T* ET
 Q
 Q
 q
@@ -11130,7 +10874,7 @@ n 132 0 24 12 re f*
 n 156 0 6 12 re f*
 .941176 .972549 1 rg
 n 162 0 0 12 re f*
-BT 1 0 0 1 0 146 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (pageTemplates) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (coverPage) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (showHeader) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (false) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (showFooter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (false) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (oneColumn) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 10 Tf 0 .501961 0 rg (twoColumn) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (49%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (51%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (49%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 146 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (pageTemplates) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (coverPage) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (showHeader) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (false) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (showFooter) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (false) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (oneColumn) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F8 10 Tf 0 .501961 0 rg (twoColumn) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (frames) Tj /F5 10 Tf 0 0 0 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (49%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (-) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ([) Tj .098039 .090196 .486275 rg (51%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (0cm) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (49%) Tj 0 0 0 rg (,) Tj .733333 .733333 .733333 rg ( ) Tj .098039 .090196 .486275 rg (100%) Tj 0 0 0 rg (]) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -11317,7 +11061,7 @@ Q
  
 endstream
 endobj
-354 0 obj
+341 0 obj
 <<
 /Length 7191
 >>
@@ -11349,7 +11093,7 @@ n 72 24 0 12 re f*
 n 0 12 0 12 re f*
 .941176 .972549 1 rg
 n 132 0 0 12 re f*
-BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (raw) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( pdf) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (   PageBreak twoColumn) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (raw) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( pdf) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (   PageBreak twoColumn) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -11365,7 +11109,7 @@ Q
 q
 1 0 0 1 57.02362 659.8236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (You can see an example of this in the ) Tj /F8 10 Tf (Montecristo) Tj /F1 10 Tf ( folder in the source package.) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (You can see an example of this in the ) Tj /F6 10 Tf (Montecristo) Tj /F1 10 Tf ( folder in the source package.) Tj T* ET
 Q
 Q
 q
@@ -11629,7 +11373,7 @@ Q
 q
 1 0 0 1 57.02362 158.6236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (rst2pdf has ) Tj /F8 10 Tf (some) Tj /F1 10 Tf ( widow/orphan control. Specifically, here's what's currently implemented:) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (rst2pdf has ) Tj /F6 10 Tf (some) Tj /F1 10 Tf ( widow/orphan control. Specifically, here's what's currently implemented:) Tj T* ET
 Q
 Q
 q
@@ -11695,7 +11439,7 @@ Q
  
 endstream
 endobj
-355 0 obj
+342 0 obj
 <<
 /Length 6438
 >>
@@ -11755,7 +11499,7 @@ n 90 0 12 12 re f*
 n 102 0 6 12 re f*
 .941176 .972549 1 rg
 n 108 0 0 12 re f*
-BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg (A literal block) Tj /F7 10 Tf .733333 .4 .133333 rg (::) Tj /F5 10 Tf 0 0 0 rg  T*  T* .729412 .129412 .129412 rg (    This is a literal block.) Tj 0 0 0 rg  T* .729412 .129412 .129412 rg  T* 0 0 0 rg (A code block:) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (..) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (code-block) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( ) Tj /F7 10 Tf 0 .501961 0 rg (python) Tj /F5 10 Tf 0 0 0 rg  T*  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (x) Tj 0 0 0 rg (\() Tj (y) Tj (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (        ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (y) Tj .4 .4 .4 rg (**) Tj (2) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg (A literal block) Tj /F8 10 Tf .733333 .4 .133333 rg (::) Tj /F5 10 Tf 0 0 0 rg  T*  T* .729412 .129412 .129412 rg (    This is a literal block.) Tj 0 0 0 rg  T* .729412 .129412 .129412 rg  T* 0 0 0 rg (A code block:) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (..) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (code-block) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( ) Tj /F8 10 Tf 0 .501961 0 rg (python) Tj /F5 10 Tf 0 0 0 rg  T*  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (x) Tj 0 0 0 rg (\() Tj (y) Tj (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (        ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (y) Tj .4 .4 .4 rg (**) Tj (2) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -11845,7 +11589,7 @@ n 0 12 6 12 re f*
 n 114 12 0 12 re f*
 .941176 .972549 1 rg
 n 114 0 0 12 re f*
-BT 1 0 0 1 0 50 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (class) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( thick) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (+-------+---------+) Tj .733333 .733333 .733333 rg  T* .4 .4 .4 rg (|) Tj 0 0 0 rg (   A   |   B     |) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (+-----------------+) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 50 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (class) Tj /F5 10 Tf 0 0 0 rg (::) Tj ( thick) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (+-------+---------+) Tj .733333 .733333 .733333 rg  T* .4 .4 .4 rg (|) Tj 0 0 0 rg (   A   |   B     |) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (+-----------------+) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -11872,7 +11616,7 @@ Q
 q
 1 0 0 1 23 33 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (It's a style that automatically applies to something that is ) Tj /F8 10 Tf (drawn) Tj /F1 10 Tf ( using a table. Currently these include:) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (It's a style that automatically applies to something that is ) Tj /F6 10 Tf (drawn) Tj /F1 10 Tf ( using a table. Currently these include:) Tj T* ET
 Q
 Q
 q
@@ -12043,7 +11787,7 @@ Q
  
 endstream
 endobj
-356 0 obj
+343 0 obj
 <<
 /Length 5180
 >>
@@ -12351,7 +12095,7 @@ Q
  
 endstream
 endobj
-357 0 obj
+344 0 obj
 <<
 /Length 10374
 >>
@@ -12437,7 +12181,7 @@ n 66 0 6 12 re f*
 n 72 0 6 12 re f*
 .941176 .972549 1 rg
 n 78 0 0 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (myFun) Tj 0 0 0 rg (\() Tj (x) Tj (,) Tj (y) Tj (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (x) Tj .4 .4 .4 rg (+) Tj 0 0 0 rg (y) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (myFun) Tj 0 0 0 rg (\() Tj (x) Tj (,) Tj (y) Tj (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (x) Tj .4 .4 .4 rg (+) Tj 0 0 0 rg (y) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -12497,7 +12241,7 @@ n 72 0 6 12 re f*
 n 78 0 6 12 re f*
 .941176 .972549 1 rg
 n 84 0 6 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F7 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (myFun) Tj 0 0 0 rg (\() Tj (x) Tj (,) Tj (y) Tj (\):) Tj  T* (2 ) Tj (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (x) Tj .4 .4 .4 rg (+) Tj 0 0 0 rg (y) Tj T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F8 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (myFun) Tj 0 0 0 rg (\() Tj (x) Tj (,) Tj (y) Tj (\):) Tj  T* (2 ) Tj (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (x) Tj .4 .4 .4 rg (+) Tj 0 0 0 rg (y) Tj T* ET
 Q
 Q
 Q
@@ -13016,7 +12760,7 @@ Q
  
 endstream
 endobj
-358 0 obj
+345 0 obj
 <<
 /Length 10676
 >>
@@ -13744,7 +13488,7 @@ n 156 12 6 12 re f*
 n 162 12 0 12 re f*
 .941176 .972549 1 rg
 n 0 0 12 12 re f*
-BT 1 0 0 1 0 26 Tm 12 TL /F7 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("python is great") Tj .733333 .733333 .733333 rg  T* /F7 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (find) Tj (\() Tj .729412 .129412 .129412 rg ('great') Tj 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* .533333 .533333 .533333 rg (10) Tj T* ET
+BT 1 0 0 1 0 26 Tm 12 TL /F8 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (=) Tj .729412 .129412 .129412 rg ("python is great") Tj .733333 .733333 .733333 rg  T* /F8 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (find) Tj (\() Tj .729412 .129412 .129412 rg ('great') Tj 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* .533333 .533333 .533333 rg (10) Tj T* ET
 Q
 Q
 Q
@@ -13793,7 +13537,7 @@ Q
  
 endstream
 endobj
-359 0 obj
+346 0 obj
 <<
 /Length 7649
 >>
@@ -13837,7 +13581,7 @@ n 174 12 6 12 re f*
 n 180 12 0 12 re f*
 .941176 .972549 1 rg
 n 0 0 24 12 re f*
-BT 1 0 0 1 0 14 Tm 12 TL /F7 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (startswith) Tj (\() Tj .729412 .129412 .129412 rg ('py') Tj 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* .533333 .533333 .533333 rg (True) Tj T* ET
+BT 1 0 0 1 0 14 Tm 12 TL /F8 10 Tf 0 0 .501961 rg (>) Tj (>) Tj (>) Tj ( ) Tj /F5 10 Tf 0 0 0 rg (my_string) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (startswith) Tj (\() Tj .729412 .129412 .129412 rg ('py') Tj 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* .533333 .533333 .533333 rg (True) Tj T* ET
 Q
 Q
 Q
@@ -13966,7 +13710,7 @@ n 114 12 204 12 re f*
 n 318 12 0 12 re f*
 .941176 .972549 1 rg
 n 0 0 36 12 re f*
-BT 1 0 0 1 0 98 Tm 12 TL /F5 10 Tf 0 .266667 .866667 rg (Traceback \(most recent call last\):) Tj T* .733333 .733333 .733333 rg (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (9) Tj 0 0 0 rg (,) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (?) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (main) Tj (\(\)) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (6) Tj 0 0 0 rg (,) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (main) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (call_error) Tj (\(\)) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (2) Tj 0 0 0 rg (,) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (call_error) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (r) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (1) Tj (/) Tj (0) Tj .733333 .733333 .733333 rg  T* 1 0 0 rg (ZeroDivisionError) Tj 0 0 0 rg (: ) Tj (integer division or modulo by zero) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (Exit 1) Tj T* ET
+BT 1 0 0 1 0 98 Tm 12 TL /F5 10 Tf 0 .266667 .866667 rg (Traceback \(most recent call last\):) Tj T* .733333 .733333 .733333 rg (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (9) Tj 0 0 0 rg (,) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (?) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (main) Tj (\(\)) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (6) Tj 0 0 0 rg (,) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (main) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 .501961 0 rg (print) Tj 0 0 0 rg ( ) Tj (call_error) Tj (\(\)) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (File) Tj ( ) Tj .729412 .129412 .129412 rg ("error.py") Tj 0 0 0 rg (,) Tj ( ) Tj (line) Tj ( ) Tj .4 .4 .4 rg (2) Tj 0 0 0 rg (,) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (in) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (call_error) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (r) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (1) Tj (/) Tj (0) Tj .733333 .733333 .733333 rg  T* 1 0 0 rg (ZeroDivisionError) Tj 0 0 0 rg (: ) Tj (integer division or modulo by zero) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (Exit 1) Tj T* ET
 Q
 Q
 Q
@@ -14051,9 +13795,9 @@ Q
  
 endstream
 endobj
-360 0 obj
+347 0 obj
 <<
-/Length 9222
+/Length 4169
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -14084,7 +13828,7 @@ n -6 -6 480.0283 36 re B*
 Q
 q
 0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F5 10 Tf 12 TL (.. code-block:: python) Tj T* (   :include: setup.py) Tj T* ET
+BT 1 0 0 1 0 14 Tm /F5 10 Tf 12 TL (.. code-block:: python) Tj T* (   :include: my_script.py) Tj T* ET
 Q
 Q
 Q
@@ -14093,7 +13837,7 @@ Q
 q
 1 0 0 1 57.02362 645.8236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This will give a warning if ) Tj /F5 10 Tf (setup.py) Tj /F1 10 Tf ( doesn't exist or can't be opened.) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This will give a warning if ) Tj /F5 10 Tf (my_script.py) Tj /F1 10 Tf ( doesn't exist or can't be opened.) Tj T* ET
 Q
 Q
 q
@@ -14198,205 +13942,20 @@ Q
 Q
 Q
 q
-1 0 0 1 57.02362 458.8236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Let's display a class from rst2pdf:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 389.6236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 60 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 38 Tm /F5 10 Tf 12 TL (.. code-block:: python) Tj T* (   :include: assets/flowables.py) Tj T* (   :start-at: class Separation\(Flowable\):) Tj T* (   :end-before: class Reference\(Flowable\):) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 369.6236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This command gives) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 240.4236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 120 re B*
-Q
-q
-.941176 .972549 1 rg
-n 0 96 30 12 re f*
-.941176 .972549 1 rg
-n 36 96 60 12 re f*
-.941176 .972549 1 rg
-n 96 96 6 12 re f*
-.941176 .972549 1 rg
-n 102 96 48 12 re f*
-.941176 .972549 1 rg
-n 150 96 12 12 re f*
-.941176 .972549 1 rg
-n 162 96 0 12 re f*
-.941176 .972549 1 rg
-n 0 84 24 12 re f*
-.941176 .972549 1 rg
-n 24 84 72 12 re f*
-.941176 .972549 1 rg
-n 96 84 6 12 re f*
-.941176 .972549 1 rg
-n 102 84 12 12 re f*
-.941176 .972549 1 rg
-n 114 84 6 12 re f*
-.941176 .972549 1 rg
-n 120 84 102 12 re f*
-.941176 .972549 1 rg
-n 222 84 0 12 re f*
-.941176 .972549 1 rg
-n 0 72 0 12 re f*
-.941176 .972549 1 rg
-n 24 60 18 12 re f*
-.941176 .972549 1 rg
-n 48 60 24 12 re f*
-.941176 .972549 1 rg
-n 72 60 6 12 re f*
-.941176 .972549 1 rg
-n 78 60 24 12 re f*
-.941176 .972549 1 rg
-n 102 60 6 12 re f*
-.941176 .972549 1 rg
-n 114 60 6 12 re f*
-.941176 .972549 1 rg
-n 120 60 6 12 re f*
-.941176 .972549 1 rg
-n 132 60 6 12 re f*
-.941176 .972549 1 rg
-n 138 60 12 12 re f*
-.941176 .972549 1 rg
-n 150 60 0 12 re f*
-.941176 .972549 1 rg
-n 48 48 24 12 re f*
-.941176 .972549 1 rg
-n 72 48 6 12 re f*
-.941176 .972549 1 rg
-n 78 48 6 12 re f*
-.941176 .972549 1 rg
-n 90 48 6 12 re f*
-.941176 .972549 1 rg
-n 102 48 6 12 re f*
-.941176 .972549 1 rg
-n 108 48 0 12 re f*
-.941176 .972549 1 rg
-n 48 36 36 12 re f*
-.941176 .972549 1 rg
-n 90 36 6 12 re f*
-.941176 .972549 1 rg
-n 96 36 6 12 re f*
-.941176 .972549 1 rg
-n 108 36 6 12 re f*
-.941176 .972549 1 rg
-n 120 36 6 12 re f*
-.941176 .972549 1 rg
-n 132 36 12 12 re f*
-.941176 .972549 1 rg
-n 144 36 0 12 re f*
-.941176 .972549 1 rg
-n 0 24 0 12 re f*
-.941176 .972549 1 rg
-n 24 12 18 12 re f*
-.941176 .972549 1 rg
-n 48 12 24 12 re f*
-.941176 .972549 1 rg
-n 72 12 6 12 re f*
-.941176 .972549 1 rg
-n 78 12 24 12 re f*
-.941176 .972549 1 rg
-n 102 12 12 12 re f*
-.941176 .972549 1 rg
-n 114 12 0 12 re f*
-.941176 .972549 1 rg
-n 48 0 24 12 re f*
-.941176 .972549 1 rg
-n 72 0 6 12 re f*
-.941176 .972549 1 rg
-n 78 0 24 12 re f*
-.941176 .972549 1 rg
-n 102 0 6 12 re f*
-.941176 .972549 1 rg
-n 108 0 24 12 re f*
-.941176 .972549 1 rg
-n 132 0 6 12 re f*
-.941176 .972549 1 rg
-n 138 0 6 12 re f*
-.941176 .972549 1 rg
-n 144 0 6 12 re f*
-.941176 .972549 1 rg
-n 156 0 18 12 re f*
-.941176 .972549 1 rg
-n 180 0 6 12 re f*
-.941176 .972549 1 rg
-n 192 0 12 12 re f*
-.941176 .972549 1 rg
-n 204 0 6 12 re f*
-.941176 .972549 1 rg
-n 216 0 24 12 re f*
-.941176 .972549 1 rg
-n 240 0 6 12 re f*
-.941176 .972549 1 rg
-n 246 0 6 12 re f*
-.941176 .972549 1 rg
-n 252 0 6 12 re f*
-.941176 .972549 1 rg
-n 264 0 18 12 re f*
-.941176 .972549 1 rg
-n 288 0 6 12 re f*
-.941176 .972549 1 rg
-n 300 0 12 12 re f*
-.941176 .972549 1 rg
-n 312 0 6 12 re f*
-.941176 .972549 1 rg
-n 318 0 0 12 re f*
-BT 1 0 0 1 0 98 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (class) Tj /F5 10 Tf 0 0 0 rg ( ) Tj /F7 10 Tf 0 0 1 rg (Separation) Tj /F5 10 Tf 0 0 0 rg (\() Tj (Flowable) Tj (\):) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F6 10 Tf .729412 .129412 .129412 rg ("""A simple ) Tj (<) Tj (hr) Tj (>) Tj (-like flowable""") Tj /F5 10 Tf .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    ) Tj /F7 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (wrap) Tj 0 0 0 rg (\() Tj 0 .501961 0 rg (self) Tj 0 0 0 rg (,) Tj ( ) Tj (w) Tj (,) Tj ( ) Tj (h) Tj (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (        ) Tj 0 .501961 0 rg (self) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (w) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj (w) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (        ) Tj /F7 10 Tf 0 .501961 0 rg (return) Tj /F5 10 Tf 0 0 0 rg ( ) Tj (w) Tj (,) Tj ( ) Tj .4 .4 .4 rg (1) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (*) Tj 0 0 0 rg ( ) Tj (cm) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    ) Tj /F7 10 Tf 0 .501961 0 rg (def) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 1 rg (draw) Tj 0 0 0 rg (\() Tj 0 .501961 0 rg (self) Tj 0 0 0 rg (\):) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (        ) Tj 0 .501961 0 rg (self) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (canv) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (line) Tj (\() Tj .4 .4 .4 rg (0) Tj 0 0 0 rg (,) Tj ( ) Tj .4 .4 .4 rg (0.5) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (*) Tj 0 0 0 rg ( ) Tj (cm) Tj (,) Tj ( ) Tj 0 .501961 0 rg (self) Tj .4 .4 .4 rg (.) Tj 0 0 0 rg (w) Tj (,) Tj ( ) Tj .4 .4 .4 rg (0.5) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (*) Tj 0 0 0 rg ( ) Tj (cm) Tj (\)) Tj .733333 .733333 .733333 rg  T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 213.4236 cm
+1 0 0 1 57.02362 449.8236 cm
 q
 BT 1 0 0 1 0 2.5 Tm 15 TL /F3 12.5 Tf .133333 .133333 .133333 rg (9.1.2   Options) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 195.4236 cm
+1 0 0 1 57.02362 431.8236 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (linenos) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 180.4236 cm
+1 0 0 1 57.02362 416.8236 cm
 q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
@@ -14413,14 +13972,14 @@ Q
 Q
 Q
 q
-1 0 0 1 57.02362 164.4236 cm
+1 0 0 1 57.02362 400.8236 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (linenos_offset) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 137.4236 cm
+1 0 0 1 57.02362 373.8236 cm
 q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
@@ -14436,7 +13995,7 @@ Q
 Q
 Q
 q
-1 0 0 1 57.02362 137.4236 cm
+1 0 0 1 57.02362 373.8236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -14481,7 +14040,7 @@ Q
  
 endstream
 endobj
-361 0 obj
+348 0 obj
 <<
 /Length 7753
 >>
@@ -14933,7 +14492,7 @@ Q
 q
 1 0 0 1 57.02362 225.8236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (And then it ) Tj /F8 10 Tf (may) Tj /F1 10 Tf ( work.) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (And then it ) Tj /F6 10 Tf (may) Tj /F1 10 Tf ( work.) Tj T* ET
 Q
 Q
 q
@@ -15051,7 +14610,7 @@ Q
  
 endstream
 endobj
-362 0 obj
+349 0 obj
 <<
 /Length 6002
 >>
@@ -15099,7 +14658,7 @@ Q
 q
 1 0 0 1 23 -3 cm
 q
-BT 1 0 0 1 0 14 Tm 1.609917 Tw 12 TL /F1 10 Tf 0 0 0 rg (You don't need to put the ) Tj /F8 10 Tf (exact) Tj /F1 10 Tf ( folder, just something that is above it. In my own case, fonty is in) Tj T* 0 Tw /F5 10 Tf (/usr/share/fonts/TTF) Tj T* ET
+BT 1 0 0 1 0 14 Tm 1.609917 Tw 12 TL /F1 10 Tf 0 0 0 rg (You don't need to put the ) Tj /F6 10 Tf (exact) Tj /F1 10 Tf ( folder, just something that is above it. In my own case, fonty is in) Tj T* 0 Tw /F5 10 Tf (/usr/share/fonts/TTF) Tj T* ET
 Q
 Q
 q
@@ -15306,7 +14865,7 @@ Q
  
 endstream
 endobj
-363 0 obj
+350 0 obj
 <<
 /Length 5305
 >>
@@ -15336,7 +14895,7 @@ Q
 q
 1 0 0 1 57.02362 689.8236 cm
 q
-BT 1 0 0 1 0 14 Tm .608334 Tw 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F8 10 Tf (embeddedFonts) Tj /F1 10 Tf ( element is a list of the font files that you want to embed into your PDF document. For) Tj T* 0 Tw (each font, you provide the filenames of the four variants of the file \(normal, bold, italic, bold italic\).) Tj T* ET
+BT 1 0 0 1 0 14 Tm .608334 Tw 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F6 10 Tf (embeddedFonts) Tj /F1 10 Tf ( element is a list of the font files that you want to embed into your PDF document. For) Tj T* 0 Tw (each font, you provide the filenames of the four variants of the file \(normal, bold, italic, bold italic\).) Tj T* ET
 Q
 Q
 q
@@ -15375,7 +14934,7 @@ Q
 q
 1 0 0 1 57.02362 540.6236 cm
 q
-BT 1 0 0 1 0 14 Tm .200966 Tw 12 TL /F1 10 Tf 0 0 0 rg (Now, if you use ) Tj /F8 10 Tf (italics) Tj /F1 10 Tf ( in a paragraph whose style uses the Tuffy font, it will use ) Tj /F5 10 Tf (Tuffy_Italic) Tj /F1 10 Tf (. That's why) Tj T* 0 Tw (it's better if you use fonts that provide the four variants, and that you list them in the correct order.) Tj T* ET
+BT 1 0 0 1 0 14 Tm .200966 Tw 12 TL /F1 10 Tf 0 0 0 rg (Now, if you use ) Tj /F6 10 Tf (italics) Tj /F1 10 Tf ( in a paragraph whose style uses the Tuffy font, it will use ) Tj /F5 10 Tf (Tuffy_Italic) Tj /F1 10 Tf (. That's why) Tj T* 0 Tw (it's better if you use fonts that provide the four variants, and that you list them in the correct order.) Tj T* ET
 Q
 Q
 q
@@ -15526,7 +15085,7 @@ Q
  
 endstream
 endobj
-364 0 obj
+351 0 obj
 <<
 /Length 4847
 >>
@@ -15783,7 +15342,7 @@ Q
  
 endstream
 endobj
-365 0 obj
+352 0 obj
 <<
 /Length 6272
 >>
@@ -16192,7 +15751,7 @@ Q
  
 endstream
 endobj
-366 0 obj
+353 0 obj
 <<
 /Length 6332
 >>
@@ -16207,7 +15766,7 @@ Q
 q
 1 0 0 1 57.02362 699.0236 cm
 q
-BT 1 0 0 1 0 14 Tm .234897 Tw 12 TL /F1 10 Tf 0 0 0 rg (Page transitions are effects used when you change pages in ) Tj /F8 10 Tf (Presentation) Tj /F1 10 Tf ( or ) Tj /F8 10 Tf (Full Screen) Tj /F1 10 Tf ( mode \(depends on) Tj T* 0 Tw (the viewer\). You can use it when creating a presentation using PDF files.) Tj T* ET
+BT 1 0 0 1 0 14 Tm .234897 Tw 12 TL /F1 10 Tf 0 0 0 rg (Page transitions are effects used when you change pages in ) Tj /F6 10 Tf (Presentation) Tj /F1 10 Tf ( or ) Tj /F6 10 Tf (Full Screen) Tj /F1 10 Tf ( mode \(depends on) Tj T* 0 Tw (the viewer\). You can use it when creating a presentation using PDF files.) Tj T* ET
 Q
 Q
 q
@@ -16524,7 +16083,7 @@ Q
 q
 1 0 0 1 57.02362 259.6236 cm
 q
-BT 1 0 0 1 0 14 Tm .391826 Tw 12 TL /F1 10 Tf 0 0 0 rg (Keep in mind that ) Tj /F5 10 Tf (Transition) Tj /F1 10 Tf ( sets the transition ) Tj /F8 10 Tf (from this page to the next) Tj /F1 10 Tf ( so the natural thing is to use it) Tj T* 0 Tw (before a ) Tj /F5 10 Tf (PageBreak) Tj /F1 10 Tf (:) Tj T* ET
+BT 1 0 0 1 0 14 Tm .391826 Tw 12 TL /F1 10 Tf 0 0 0 rg (Keep in mind that ) Tj /F5 10 Tf (Transition) Tj /F1 10 Tf ( sets the transition ) Tj /F6 10 Tf (from this page to the next) Tj /F1 10 Tf ( so the natural thing is to use it) Tj T* 0 Tw (before a ) Tj /F5 10 Tf (PageBreak) Tj /F1 10 Tf (:) Tj T* ET
 Q
 Q
 q
@@ -16632,7 +16191,7 @@ Q
  
 endstream
 endobj
-367 0 obj
+354 0 obj
 <<
 /Length 1261
 >>
@@ -16703,7 +16262,7 @@ Q
  
 endstream
 endobj
-368 0 obj
+355 0 obj
 <<
 /Length 4930
 >>
@@ -16826,7 +16385,7 @@ n 348 0 6 12 re f*
 n 354 0 12 12 re f*
 .941176 .972549 1 rg
 n 366 0 0 12 re f*
-BT 1 0 0 1 0 86 Tm 12 TL /F5 10 Tf 0 0 0 rg (Start a counter called seq1 that starts from 1: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq1`) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (Now this should print 2: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq1`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (You can start counters from any number \(this prints 12\): ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq2:12`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (And have any number of counters with any name: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`figures`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (So ) Tj .729412 .129412 .129412 rg (``#seq1-2``) Tj 0 0 0 rg ( should link to ) Tj .729412 .129412 .129412 rg (`the number 2 above ) Tj /F7 10 Tf .733333 .4 .533333 rg (<) Tj (#seq1-2) Tj (>) Tj /F5 10 Tf .729412 .129412 .129412 rg (`_) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 86 Tm 12 TL /F5 10 Tf 0 0 0 rg (Start a counter called seq1 that starts from 1: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq1`) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (Now this should print 2: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq1`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (You can start counters from any number \(this prints 12\): ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`seq2:12`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (And have any number of counters with any name: ) Tj .490196 .564706 .160784 rg (:counter:) Tj .098039 .090196 .486275 rg (`figures`) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (So ) Tj .729412 .129412 .129412 rg (``#seq1-2``) Tj 0 0 0 rg ( should link to ) Tj .729412 .129412 .129412 rg (`the number 2 above ) Tj /F8 10 Tf .733333 .4 .533333 rg (<) Tj (#seq1-2) Tj (>) Tj /F5 10 Tf .729412 .129412 .129412 rg (`_) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -16915,7 +16474,7 @@ Q
  
 endstream
 endobj
-369 0 obj
+356 0 obj
 <<
 /Length 2935
 >>
@@ -17090,7 +16649,7 @@ Q
  
 endstream
 endobj
-370 0 obj
+357 0 obj
 <<
 /Length 4624
 >>
@@ -17168,7 +16727,7 @@ n 0 24 0 12 re f*
 n 450 12 0 12 re f*
 .941176 .972549 1 rg
 n 90 0 0 12 re f*
-BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (oddeven) Tj /F5 10 Tf 0 0 0 rg (::) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    ..) Tj ( ) Tj /F7 10 Tf .666667 .133333 1 rg (container) Tj /F5 10 Tf 0 0 0 rg (::) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (        This will appear on odd pages.) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (        Both paragraphs in the container are for odd pages.) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    This will appear on even pages. It's a single paragraph, so no need for) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (    containers.) Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (oddeven) Tj /F5 10 Tf 0 0 0 rg (::) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    ..) Tj ( ) Tj /F8 10 Tf .666667 .133333 1 rg (container) Tj /F5 10 Tf 0 0 0 rg (::) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (        This will appear on odd pages.) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (        Both paragraphs in the container are for odd pages.) Tj .733333 .733333 .733333 rg  T*  T* 0 0 0 rg (    This will appear on even pages. It's a single paragraph, so no need for) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (    containers.) Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -17309,7 +16868,7 @@ Q
  
 endstream
 endobj
-371 0 obj
+358 0 obj
 <<
 /Length 4786
 >>
@@ -17367,9 +16926,9 @@ q
 0 0 0 rg
 BT 1 0 0 1 0 4.825313 Tm /F9+0 7 Tf 8.4 TL (2) Tj T* ET
 0 0 0 rg
-BT 1 0 0 1 5.817383 4.825313 Tm /F9+0 7 Tf 8.4 TL (\200) Tj T* ET
+BT 1 0 0 1 5.817383 4.825313 Tm /F9+0 7 Tf 8.4 TL (\001) Tj T* ET
 0 0 0 rg
-BT 1 0 0 1 13.04639 6.06125 Tm /F10+0 3.950085 Tf 4.740102 TL (\200) Tj T* ET
+BT 1 0 0 1 13.04639 6.06125 Tm /F10+0 3.950085 Tf 4.740102 TL (\001) Tj T* ET
 0 0 0 rg
 BT 1 0 0 1 18.08333 4.454688 Tm /F9+0 7 Tf 8.4 TL (7) Tj T* ET
 0 0 0 rg
@@ -17386,7 +16945,7 @@ q
 6 0 0 8 280.68 1 cm
 /FormXob.0ba901e64a80f2e0e4e27e23b621fb7f Do
 Q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (If you want to insert mathematical notation in your text like this: ) Tj 286.68 0 Td ( that is the job of the math ) Tj /F8 10 Tf (role) Tj /F1 10 Tf (:) Tj T* -286.68 0 Td ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (If you want to insert mathematical notation in your text like this: ) Tj 286.68 0 Td ( that is the job of the math ) Tj /F6 10 Tf (role) Tj /F1 10 Tf (:) Tj T* -286.68 0 Td ET
 Q
 Q
 q
@@ -17557,7 +17116,7 @@ Q
  
 endstream
 endobj
-372 0 obj
+359 0 obj
 <<
 /Length 3947
 >>
@@ -17728,7 +17287,7 @@ Q
  
 endstream
 endobj
-373 0 obj
+360 0 obj
 <<
 /Length 4571
 >>
@@ -17973,7 +17532,7 @@ Q
  
 endstream
 endobj
-374 0 obj
+361 0 obj
 <<
 /Length 4685
 >>
@@ -18173,7 +17732,7 @@ Q
  
 endstream
 endobj
-375 0 obj
+362 0 obj
 <<
 /Length 2483
 >>
@@ -18254,7 +17813,7 @@ Q
  
 endstream
 endobj
-376 0 obj
+363 0 obj
 <<
 /Length 5779
 >>
@@ -18379,7 +17938,7 @@ n 54 0 6 12 re f*
 n 60 0 300 12 re f*
 .941176 .972549 1 rg
 n 360 0 0 12 re f*
-BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 1 rg (pdf) Tj .4 .4 .4 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F7 10 Tf 0 .501961 0 rg ($\() Tj /F5 10 Tf 0 0 0 rg (SPHINXBUILD) Tj /F7 10 Tf 0 .501961 0 rg (\)) Tj /F5 10 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (-b) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (pdf) Tj .733333 .733333 .733333 rg ( ) Tj /F7 10 Tf 0 .501961 0 rg ($\() Tj /F5 10 Tf 0 0 0 rg (ALLSPHINXOPTS) Tj /F7 10 Tf 0 .501961 0 rg (\)) Tj /F5 10 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (_build/pdf) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (@echo) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (@echo) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg ("Build finished. The PDF files are in _build/pdf.") Tj .733333 .733333 .733333 rg  T* ET
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 1 rg (pdf) Tj .4 .4 .4 rg (:) Tj .733333 .733333 .733333 rg  T* (    ) Tj /F8 10 Tf 0 .501961 0 rg ($\() Tj /F5 10 Tf 0 0 0 rg (SPHINXBUILD) Tj /F8 10 Tf 0 .501961 0 rg (\)) Tj /F5 10 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (-b) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (pdf) Tj .733333 .733333 .733333 rg ( ) Tj /F8 10 Tf 0 .501961 0 rg ($\() Tj /F5 10 Tf 0 0 0 rg (ALLSPHINXOPTS) Tj /F8 10 Tf 0 .501961 0 rg (\)) Tj /F5 10 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (_build/pdf) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (@echo) Tj .733333 .733333 .733333 rg  T* (    ) Tj 0 0 0 rg (@echo) Tj .733333 .733333 .733333 rg ( ) Tj .729412 .129412 .129412 rg ("Build finished. The PDF files are in _build/pdf.") Tj .733333 .733333 .733333 rg  T* ET
 Q
 Q
 Q
@@ -18437,7 +17996,7 @@ n 24 12 24 12 re f*
 n 54 12 18 12 re f*
 .941176 .972549 1 rg
 n 0 0 6 12 re f*
-BT 1 0 0 1 0 62 Tm 12 TL /F7 10 Tf 0 .501961 0 rg (if) Tj /F5 10 Tf 0 0 0 rg ( ) Tj .729412 .129412 .129412 rg (") Tj .098039 .090196 .486275 rg (%1) Tj .729412 .129412 .129412 rg (") Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (==) Tj 0 0 0 rg ( ) Tj .729412 .129412 .129412 rg ("pdf") Tj 0 0 0 rg ( ) Tj (\() Tj  T* (    ) Tj .098039 .090196 .486275 rg (%SPHINXBUILD%) Tj 0 0 0 rg ( -b pdf ) Tj .098039 .090196 .486275 rg (%ALLSPHINXOPTS%) Tj 0 0 0 rg ( ) Tj .098039 .090196 .486275 rg (%BUILDDIR%) Tj 0 0 0 rg (/pdf) Tj T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (echo) Tj /F5 10 Tf 0 0 0 rg (.) Tj T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (echo) Tj /F5 10 Tf 0 0 0 rg (.Build finished. The PDF files are in ) Tj .098039 .090196 .486275 rg (%BUILDDIR%) Tj 0 0 0 rg (/pdf) Tj T* (    ) Tj /F7 10 Tf 0 .501961 0 rg (goto) Tj /F5 10 Tf 0 0 0 rg ( ) Tj .627451 .627451 0 rg (end) Tj 0 0 0 rg  T* (\)) Tj T* ET
+BT 1 0 0 1 0 62 Tm 12 TL /F8 10 Tf 0 .501961 0 rg (if) Tj /F5 10 Tf 0 0 0 rg ( ) Tj .729412 .129412 .129412 rg (") Tj .098039 .090196 .486275 rg (%1) Tj .729412 .129412 .129412 rg (") Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (==) Tj 0 0 0 rg ( ) Tj .729412 .129412 .129412 rg ("pdf") Tj 0 0 0 rg ( ) Tj (\() Tj  T* (    ) Tj .098039 .090196 .486275 rg (%SPHINXBUILD%) Tj 0 0 0 rg ( -b pdf ) Tj .098039 .090196 .486275 rg (%ALLSPHINXOPTS%) Tj 0 0 0 rg ( ) Tj .098039 .090196 .486275 rg (%BUILDDIR%) Tj 0 0 0 rg (/pdf) Tj T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (echo) Tj /F5 10 Tf 0 0 0 rg (.) Tj T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (echo) Tj /F5 10 Tf 0 0 0 rg (.Build finished. The PDF files are in ) Tj .098039 .090196 .486275 rg (%BUILDDIR%) Tj 0 0 0 rg (/pdf) Tj T* (    ) Tj /F8 10 Tf 0 .501961 0 rg (goto) Tj /F5 10 Tf 0 0 0 rg ( ) Tj .627451 .627451 0 rg (end) Tj 0 0 0 rg  T* (\)) Tj T* ET
 Q
 Q
 Q
@@ -18509,9 +18068,9 @@ Q
  
 endstream
 endobj
-377 0 obj
+364 0 obj
 <<
-/Length 7301
+/Length 3084
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -18524,57 +18083,104 @@ Q
 q
 1 0 0 1 57.02362 696.0236 cm
 q
-BT 1 0 0 1 0 14 Tm .547397 Tw 12 TL /F1 10 Tf 0 0 0 rg (rst2pdf can get new features from ) Tj /F8 10 Tf (extensions) Tj /F1 10 Tf (. Extensions are python modules that can be enabled with the) Tj T* 0 Tw /F5 10 Tf (-e) Tj /F1 10 Tf ( option.) Tj T* ET
+BT 1 0 0 1 0 14 Tm .547397 Tw 12 TL /F1 10 Tf 0 0 0 rg (rst2pdf can get new features from ) Tj /F6 10 Tf (extensions) Tj /F1 10 Tf (. Extensions are python modules that can be enabled with the) Tj T* 0 Tw /F5 10 Tf (-e) Tj /F1 10 Tf ( option.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 678.0236 cm
+1 0 0 1 57.02362 666.0236 cm
 q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Several are included with rst2pdf.) Tj T* ET
+BT 1 0 0 1 0 14 Tm 3.36631 Tw 12 TL /F1 10 Tf 0 0 0 rg (Several are included with rst2pdf, and you can also develop extensions yourself. Find the included) Tj T* 0 Tw 0 .4 .6 rg (extensions) Tj 0 0 0 rg ( by inspecting the codebase, each file includes some additional information about the extension.) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 648.0236 cm
 q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (19.1   Preprocess \() Tj /F5 15 Tf 0 0 0 rg (-e) Tj ( ) Tj (preprocess) Tj /F3 15 Tf .133333 .133333 .133333 rg (\)) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Extensions include with rst2pdf:) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 630.0236 cm
+1 0 0 1 57.02362 642.0236 cm
+Q
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (preprocess is a rst2pdf extension module \(invoked by ) Tj /F5 10 Tf (-e) Tj ( ) Tj (preprocess) Tj /F1 10 Tf ( on the rst2pdf command line\).) Tj T* ET
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 618.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm -0.11598 Tw 12 TL /F5 10 Tf 0 0 0 rg (dotted_toc) Tj /F1 10 Tf ( - a \(very\) experimental extension to add dots to the table of contents list between the titles) Tj T* 0 Tw (and the page numbers.) Tj T* ET
+Q
+Q
+q
+Q
 Q
 Q
 q
 1 0 0 1 57.02362 612.0236 cm
+Q
+q
+1 0 0 1 57.02362 600.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (There is a testcase for this file at tests/test_preprocess.txt) Tj T* ET
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (fancy_titles) Tj /F1 10 Tf ( - an experimental extension to render headings with an SVG template.) Tj T* ET
+Q
+Q
+q
+Q
 Q
 Q
 q
 1 0 0 1 57.02362 594.0236 cm
+Q
+q
+1 0 0 1 57.02362 582.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This preprocesses the source text file before handing it to docutils.) Tj T* ET
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (plantuml_r2p) Tj /F1 10 Tf ( - basic PlantUML support.) Tj T* ET
+Q
+Q
+q
+Q
 Q
 Q
 q
 1 0 0 1 57.02362 576.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This module serves two purposes:) Tj T* ET
-Q
 Q
 q
-1 0 0 1 57.02362 570.0236 cm
-Q
-q
-1 0 0 1 57.02362 570.0236 cm
-Q
-q
-1 0 0 1 57.02362 546.0236 cm
+1 0 0 1 57.02362 552.0236 cm
 q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
@@ -18582,14 +18188,13 @@ q
 1 0 0 1 6 9 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (1.) Tj T* -2 0 Td ET
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
 Q
 Q
 q
 1 0 0 1 23 -3 cm
 q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .732739 Tw (It demonstrates the technique and can be a starting point for similar user-written processing modules;) Tj T* 0 Tw (and) Tj T* ET
+BT 1 0 0 1 0 14 Tm .795223 Tw 12 TL /F5 10 Tf 0 0 0 rg (preprocess) Tj /F1 10 Tf ( - preprocessing tool to make source file changes before handing it to docutils, can help) Tj T* 0 Tw (keep compatibility between different output destinations.) Tj T* ET
 Q
 Q
 q
@@ -18597,227 +18202,10 @@ Q
 Q
 Q
 q
-1 0 0 1 57.02362 540.0236 cm
+1 0 0 1 57.02362 552.0236 cm
 Q
 q
-1 0 0 1 57.02362 516.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 2 0 Td (2.) Tj T* -2 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .606147 Tw (It provides a simplified syntax for documents which are targeted only at rst2pdf, rather than docutils in) Tj T* 0 Tw (general.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 516.0236 cm
-Q
-q
-1 0 0 1 57.02362 486.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.027455 Tw (The design goal of "base rst2pdf" is to be completely compatible with docutils, such that a file which works as) Tj T* 0 Tw (a PDF can also work as HTML, etc.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 444.0236 cm
-q
-BT 1 0 0 1 0 26 Tm 2.143223 Tw 12 TL /F1 10 Tf 0 0 0 rg (Unfortunately, base docutils is a slow-moving target, and does not make this easy. For example, SVG) Tj T* 0 Tw .210464 Tw (images do not work properly with the HTML backend unless you install a patch, and docutils has no concept) Tj T* 0 Tw (of page breaks or additional vertical space \(other than the <) Tj (hr) Tj (>) Tj (\).) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 402.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.222545 Tw (So, while it would be nice to have documents that render perfectly with any backend, this goal is hard to) Tj T* 0 Tw .236772 Tw (achieve for some documents, and once you are restricted to a particular transformation type, then you might) Tj T* 0 Tw (as well have a slightly nicer syntax for your source document.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 373.6772 cm
-0 0 0 RG
-n 0 14.17323 m 481.2283 14.17323 l S
-Q
-q
-1 0 0 1 57.02362 355.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Preprocessor extensions:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 337.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (All current extensions except style occupy a single line in the source file.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 319.6772 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj (include::) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 313.6772 cm
-Q
-q
-1 0 0 1 57.02362 277.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .756755 Tw (Processes the include file as well. An include file may either be a restructured text file, OR may be an) Tj T* 0 Tw .247417 Tw (RSON or JSON stylesheet. The determination is made by trying to parse it as RSON. If it passes, it is a) Tj T* 0 Tw (stylesheet; if not, well, we'll let the docutils parser have its way with it.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 277.6772 cm
-Q
-q
-1 0 0 1 57.02362 259.6772 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj (page::) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 253.6772 cm
-Q
-q
-1 0 0 1 57.02362 241.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Is translated into a raw PageBreak.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 241.6772 cm
-Q
-q
-1 0 0 1 57.02362 223.6772 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj (space::) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 217.6772 cm
-Q
-q
-1 0 0 1 57.02362 193.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.033771 Tw (Is translated into a raw Spacer. If only one number given, is used for vertical space. This is the canonical) Tj T* 0 Tw (use case, since horizontal space is ignored anyway!) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 193.6772 cm
-Q
-q
-1 0 0 1 57.02362 175.6772 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj (style::) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 169.6772 cm
-Q
-q
-1 0 0 1 57.02362 145.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .31131 Tw (Allows you to create in-line stylesheets. As with other restructured text components, the stylesheet data) Tj T* 0 Tw (must be indented. Stylesheets are in RSON or JSON.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 145.6772 cm
-Q
-q
-1 0 0 1 57.02362 127.6772 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (..) Tj ( ) Tj (widths::) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 121.6772 cm
-Q
-q
-1 0 0 1 57.02362 85.67717 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .457686 Tw (creates a new table style \(based on table or the first non-numeric token\) and creates a class using that) Tj T* 0 Tw .458797 Tw (style specifically for the next table in the document. \(Creates a .. class::, so you must specify .. widths::) Tj T* 0 Tw (immediately before the table it applies to. Allows you to set the widths for the table, using percentages.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 85.67717 cm
-Q
-q
-1 0 0 1 57.02362 67.67717 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (SingleWordAtLeftColumn) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 62.69291 cm
+1 0 0 1 57.02362 552.0236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -18863,166 +18251,26 @@ Q
  
 endstream
 endobj
-378 0 obj
+365 0 obj
 <<
-/Length 4807
+/Length 835
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
-1 0 0 1 57.02362 699.0236 cm
+1 0 0 1 57.02362 726.0236 cm
 q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 0 2 Tm  T* ET
-q
-1 0 0 1 20 0 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL 1.401667 Tw (If a single word at the left column is surrounded by blank lines, the singleword style is automatically) Tj T* 0 Tw 1.957223 Tw (applied to the word. This is a workaround for the broken interaction between docutils subtitles and) Tj T* 0 Tw .142556 Tw (bibliographic metadata. \(I found that docutils was referencing my subtitles from inside the TOC, and that) Tj T* 0 Tw (seemed silly. Perhaps there is a better workaround at a lower level in rst2pdf.\)) Tj T* ET
+BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (20   Developers) Tj T* ET
 Q
 Q
 q
-Q
+1 0 0 1 57.02362 708.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (To contribute to rst2pdf, visit the ) Tj 0 .4 .6 rg (project) Tj 0 0 0 rg ( on GitHub to get started.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 699.0236 cm
-Q
-q
-1 0 0 1 57.02362 670.6772 cm
-0 0 0 RG
-n 0 14.17323 m 481.2283 14.17323 l S
-Q
-q
-1 0 0 1 57.02362 652.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Preprocessor operation:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 622.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .12402 Tw (The preprocessor generates a file that has the same name as the source file, with .build_temp. embedded in) Tj T* 0 Tw (the name, and then passes that file to the restructured text parser.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 580.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 2.157686 Tw (This file is left on the disk after operation, because any error messages from docutils will refer to line) Tj T* 0 Tw .519353 Tw (numbers in it, rather than in the original source, so debugging could be difficult if the file were automatically) Tj T* 0 Tw (removed.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 550.6772 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (19.2   Dotted_TOC \() Tj /F5 15 Tf 0 0 0 rg (-e) Tj ( ) Tj (dotted_toc) Tj /F3 15 Tf .133333 .133333 .133333 rg (\)) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 520.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .057686 Tw (All I did was take the wrap\(\) method from the stock reportlab TOC generator, and make the minimal changes) Tj T* 0 Tw (to make it work on MY documents in rst2pdf.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 502.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (History:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 472.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .645197 Tw (The reportlab TOC generator adds nice dots between the text and the page number. The rst2pdf one does) Tj T* 0 Tw (not.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 442.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 2.01631 Tw (A closer examination reveals that the rst2pdf one probably deliberately stripped this code, because the) Tj T* 0 Tw -0.040103 Tw (reportlab implementation only allowed a single TOC, and this is unacceptable for at least some rst2pdf users.) Tj T* 0 Tw ET
-Q
-Q
-q
-1 0 0 1 57.02362 400.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.033071 Tw (There are other differences in the rst2pdf one I don't understand. This module is a hack to add back dots) Tj T* 0 Tw .067754 Tw (between the lines. Maybe at some point we can figure out if this is right, or how to support dots in the TOC in) Tj T* 0 Tw (the main code.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 382.6772 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Mind you, the original RL implementation is a complete hack in any case:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 376.6772 cm
-Q
-q
-1 0 0 1 57.02362 376.6772 cm
-Q
-q
-1 0 0 1 57.02362 352.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.13245 Tw (It uses a callback to a nested function which doesn't even bother to assume the original enclosing scope) Tj T* 0 Tw (is available at callback time. This leads it to do crazy things like eval\(\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 346.6772 cm
-Q
-q
-1 0 0 1 57.02362 322.6772 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .571575 Tw (It uses a single name in the canvas for the callback function \(this is what kills multiple TOC capability\)) Tj T* 0 Tw (when it would be extremely easy to generate a unique name.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 322.6772 cm
-Q
-q
-1 0 0 1 57.02362 322.6772 cm
+1 0 0 1 57.02362 708.0236 cm
 Q
 q
 1 0 0 1 51.02362 767.1969 cm
@@ -19042,7 +18290,7 @@ BT /F1 10 Tf 12 TL ET
 q
 1 0 0 1 104.6457 3 cm
 q
-BT 1 0 0 1 0 2 Tm 66.0985 0 Td 12 TL /F1 10 Tf 0 0 0 rg (19.2   Dotted_TOC \(-e) Tj ( ) Tj (dotted_toc\)) Tj T* -66.0985 0 Td ET
+BT 1 0 0 1 0 2 Tm 106.9535 0 Td 12 TL /F1 10 Tf 0 0 0 rg (20   Developers) Tj T* -106.9535 0 Td ET
 Q
 Q
 q
@@ -19067,954 +18315,16 @@ Q
  
 endstream
 endobj
-379 0 obj
+366 0 obj
 <<
-/Length 5708
+/Length 4266
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
 1 0 0 1 57.02362 726.0236 cm
 q
-BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (20   Developers) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 696.0236 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (20.1   Guidelines) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 678.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (If you want to do something inside rst2pdf, you are welcome! The process looks something like this:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 672.0236 cm
-Q
-q
-1 0 0 1 57.02362 672.0236 cm
-Q
-q
-1 0 0 1 57.02362 660.0236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Create an Issue for the task at ) Tj 0 .4 .6 rg (https://github.com/rst2pdf/rst2pdf/issues) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 654.0236 cm
-Q
-q
-1 0 0 1 57.02362 417.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 221.4 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 221.4 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (If you intend to fix a bug:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 23 215.4 cm
-Q
-q
-1 0 0 1 23 215.4 cm
-Q
-q
-1 0 0 1 23 203.4 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Create a ) Tj /F4 10 Tf (minimal) Tj /F1 10 Tf ( test case that shows the bug.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 23 197.4 cm
-Q
-q
-1 0 0 1 23 185.4 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Put it inside ) Tj /F5 10 Tf (tests/input) Tj /F1 10 Tf ( like the others:) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 23 179.4 cm
-Q
-q
-1 0 0 1 23 45 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 119.4 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 119.4 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fix the bug) Tj T* ET
-Q
-Q
-q
-1 0 0 1 23 101.4 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (During this process, you can run the individual test case to quickly iterate. For example:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 23 68.2 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 434.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pytest tests/input/test_summary_of_test.txt) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 23 42.2 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (You may also wish to check the logs and output:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 434.0283 36 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F5 10 Tf 12 TL (less tests/output/test_summary_of_test.log) Tj T* (xdg-open tests/output/test_summary_of_test.pdf  # or 'open' on macOS) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 23 39 cm
-Q
-q
-1 0 0 1 23 15 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 14 Tm 1.329873 Tw 12 TL /F1 10 Tf 0 0 0 rg (Once resolved, copy the generated output PDF, if any, to ) Tj /F5 10 Tf (tests/reference) Tj /F1 10 Tf ( and commit this) Tj T* 0 Tw (along with the files in ) Tj /F5 10 Tf (tests/input) Tj /F1 10 Tf (.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 23 9 cm
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Submit a pull request.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 411.6236 cm
-Q
-q
-1 0 0 1 57.02362 387.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 14 Tm .048726 Tw 12 TL /F1 10 Tf 0 0 0 rg (If you added a command line option, document it in ) Tj /F5 10 Tf (doc/rst2pdf.txt) Tj /F1 10 Tf (. That will make it appear in the) Tj T* 0 Tw (manual and in the man page.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 381.6236 cm
-Q
-q
-1 0 0 1 57.02362 357.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-BT 1 0 0 1 0 14 Tm .198797 Tw 12 TL /F1 10 Tf 0 0 0 rg (If you implemented a new feature, please document it in ) Tj /F5 10 Tf (manual.rst) Tj /F1 10 Tf ( \(or in a separate file and add an) Tj T* 0 Tw (include in ) Tj /F5 10 Tf (manual.rst) Tj /F1 10 Tf (\)) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 351.6236 cm
-Q
-q
-1 0 0 1 57.02362 327.6236 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 9 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
-Q
-Q
-q
-1 0 0 1 23 -3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .635785 Tw (If you implement an extension, make the docstring valid restructured text and link it to the manual like) Tj T* 0 Tw (the others.) Tj T* ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 327.6236 cm
-Q
-q
-1 0 0 1 57.02362 327.6236 cm
-Q
-q
-1 0 0 1 51.02362 767.1969 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page 48) Tj T* ET
-Q
-Q
-q
-1 0 0 1 104.6457 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 106.9535 0 Td (20   Developers) Tj T* -106.9535 0 Td ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
- 
-endstream
-endobj
-380 0 obj
-<<
-/Length 5800
->>
-stream
-1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
-q
-1 0 0 1 57.02362 726.0236 cm
-q
-BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (21   Initial checkout) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 708.0236 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Clone the repo from ) Tj 0 .4 .6 rg (https://github.com/rst2pdf/rst2pdf) Tj 0 0 0 rg (, then install and activate a venv:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 638.8236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 60 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 38 Tm /F5 10 Tf 12 TL (git clone https://github.com/rst2pdf/rst2pdf) Tj T* (cd rst2pdf) Tj T* (python3 -m venv .venv) Tj T* (. .venv/bin/activate) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 618.8236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Ensure that setuptools and pip are up to date:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 585.6236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pip install --upgrade setuptools pip) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 565.6236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Now you can install rst2pdf from this source code:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 538.7695 cm
-q
-q
-.748178 0 0 .748178 0 0 cm
-q
-1 0 0 1 6.6 8.821425 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 642 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pip install  -c requirements.txt -e .[aafiguresupport,mathsupport,rawhtmlsupport,sphinx,svgsupport,tests]) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 518.7695 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Note, that on Apple Silicon Macs, you may need this to get tests passing:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 488.362 cm
-q
-q
-.889188 0 0 .889188 0 0 cm
-q
-1 0 0 1 6.6 7.422505 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 540 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pip install reportlab==3.6.12 --force-reinstall --no-cache-dir --global-option=build_ext) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 468.362 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (\(Look in ) Tj /F5 10 Tf (requirements.txt) Tj /F1 10 Tf ( for the version of reportlab to use.\)) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 450.362 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (You can now work on rst2pdf development. Once complete, you can deactivate the venv with ) Tj /F5 10 Tf (deactivate) Tj /F1 10 Tf (.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 420.362 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (21.1   Git config) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 390.362 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .159314 Tw (After the mass-reformatting in PR 877, it is helpful to ignore the relevant commits that simply reformatted the) Tj T* 0 Tw (code when using git blame.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 360.362 cm
-q
-BT 1 0 0 1 0 14 Tm .365522 Tw 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (..git-blame-ignore-revs) Tj /F1 10 Tf ( file contains the list of commits to ignore and you can use this git config) Tj T* 0 Tw (line to make ) Tj /F5 10 Tf (git) Tj ( ) Tj (blame) Tj /F1 10 Tf ( work more usefully:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 327.162 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (git config blame.ignoreRevsFile .git-blame-ignore-revs) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 297.162 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (21.2   Pre-commit) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 267.162 cm
-q
-BT 1 0 0 1 0 14 Tm 1.187025 Tw 12 TL /F8 10 Tf 0 0 0 rg (rst2pdf) Tj /F1 10 Tf ( uses the ) Tj 0 .4 .6 rg (pre-commit) Tj 0 0 0 rg ( framework to automate various style checkers. This must be enabled locally.) Tj T* 0 Tw (You can install this using ) Tj /F8 10 Tf (pip) Tj /F1 10 Tf ( or your local package manager. For example, to install using ) Tj /F8 10 Tf (pip) Tj /F1 10 Tf (:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 233.962 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pip install pre-commit) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 213.962 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Once installed, enable it like so:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 180.762 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pre-commit install --allow-missing-config) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 148.762 cm
-q
-BT 1 0 0 1 0 14 Tm 1.486556 Tw 12 TL /F1 10 Tf 0 0 0 rg (If pre-commit locally behaves differently to CI, then run ) Tj /F5 10 Tf (pre-commit) Tj ( ) Tj (clean) Tj /F1 10 Tf ( to clear your cache before) Tj T* 0 Tw (further investigation.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 118.762 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (21.3   Continuous Integration) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 88.762 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .860439 Tw (There's a GitHub Actions workflow that runs when we open a pull request or merge to main, it does some) Tj T* 0 Tw (style checks and runs the test suite.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 51.02362 767.1969 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 104.6457 3 cm
-q
-BT 1 0 0 1 0 2 Tm 99.1685 0 Td 12 TL /F1 10 Tf 0 0 0 rg (21   Initial checkout) Tj T* -99.1685 0 Td ET
-Q
-Q
-q
-1 0 0 1 400.5827 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 49.39567 0 Td (Page 49) Tj T* -49.39567 0 Td ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
- 
-endstream
-endobj
-381 0 obj
-<<
-/Length 5108
->>
-stream
-1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
-q
-1 0 0 1 57.02362 729.0236 cm
-q
-BT 1 0 0 1 0 3 Tm 18 TL /F3 15 Tf .133333 .133333 .133333 rg (21.4   Running tests) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 663.0236 cm
-q
-BT 1 0 0 1 0 50 Tm 2.30789 Tw 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F8 10 Tf (rst2pdf) Tj /F1 10 Tf ( test suite generates PDFs - stored in ) Tj /F5 10 Tf (tests/output) Tj /F1 10 Tf ( - which are then compared against) Tj T* 0 Tw -0.075444 Tw (reference PDFs - stored in ) Tj /F5 10 Tf (tests/reference) Tj /F1 10 Tf ( - using the ) Tj 0 .4 .6 rg (PyMuPDF) Tj 0 0 0 rg ( Python bindings for the ) Tj 0 .4 .6 rg (MuPDF) Tj 0 0 0 rg ( library.) Tj T* 0 Tw .176575 Tw /F8 10 Tf (rst2pdf) Tj /F1 10 Tf ( depends on a number of different tools and libraries, such as ) Tj 0 .4 .6 rg (ReportLab) Tj 0 0 0 rg (, and the output of these can) Tj T* 0 Tw .258726 Tw (vary slightly between releases. The ) Tj /F8 10 Tf (PyMuPDF) Tj /F1 10 Tf ( library allows us to compare the structure of the PDFs, with a) Tj T* 0 Tw (minor amount of fuzzing to allow for minor differences caused by these changes in underlying dependencies.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 645.0236 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (To run all the tests enable your venv first if it's not enabled and then call ) Tj /F5 10 Tf (pytest) Tj /F1 10 Tf (:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 611.8236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pytest) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 591.8236 cm
-q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (You can also run tests in parallel using ) Tj /F5 10 Tf (pytest-xdist) Tj /F1 10 Tf ( by passing the ) Tj /F5 10 Tf (-n) Tj ( ) Tj (auto) Tj /F1 10 Tf ( flag.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 573.8236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Firstly install:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 540.6236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pip install pytest-xdist) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 520.6236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Then run the tests in parallel:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 487.4236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pytest -n auto) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 460.4236 cm
-q
-BT 1 0 0 1 0 2.5 Tm 15 TL /F3 12.5 Tf .133333 .133333 .133333 rg (21.4.1   Running a single test) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 442.4236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (To run one test only, simply pass the file or directory to pytest. For example:) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 409.2236 cm
-q
-q
-1 0 0 1 0 0 cm
-q
-1 0 0 1 6.6 6.6 cm
-q
-.662745 .662745 .662745 RG
-.5 w
-.941176 .972549 1 rg
-n -6 -6 480.0283 24 re B*
-Q
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (pytest tests/input/sphinx-repeat-table-rows) Tj T* ET
-Q
-Q
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 389.2236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This will run one test and show the output.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 362.2236 cm
-q
-BT 1 0 0 1 0 2.5 Tm 15 TL /F3 12.5 Tf .133333 .133333 .133333 rg (21.4.2   Skipping tests) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 308.2236 cm
-q
-BT 1 0 0 1 0 38 Tm .686147 Tw 12 TL /F1 10 Tf 0 0 0 rg (To skip a test, simply create a text file in the ) Tj /F5 10 Tf (tests/input) Tj /F1 10 Tf ( directory called ) Tj /F5 10 Tf ([test].ignore) Tj /F1 10 Tf ( containing a) Tj T* 0 Tw .895159 Tw (note on why the test is skipped. This will mark the test as skipped when the test suite runs. This could be) Tj T* 0 Tw 2.157686 Tw (useful for inherited tests that we aren't confident of the correct output for, but where we don't want to) Tj T* 0 Tw (delete/lose the test entirely.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 296.2236 cm
-Q
-q
-1 0 0 1 57.02362 213.2236 cm
-q
-1 .972549 .862745 rg
-n 0 83 481.2283 -83 re f*
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-BT 1 0 0 1 6 57 Tm  T* ET
-q
-1 0 0 1 16 52 cm
-q
-.133333 .133333 .133333 rg
-BT 1 0 0 1 0 2.5 Tm /F3 12.5 Tf 15 TL (Note) Tj T* ET
-Q
-Q
-q
-1 0 0 1 16 16 cm
-q
-BT 1 0 0 1 0 14 Tm .32789 Tw 12 TL /F1 10 Tf 0 0 0 rg (Some tests require the execution of the ) Tj /F5 10 Tf (dot) Tj /F1 10 Tf ( command, you should install the package graphviz from) Tj T* 0 Tw (your packages manager.) Tj T* ET
-Q
-Q
-q
-1 J
-1 j
-.662745 .662745 .662745 RG
-.5 w
-n 0 83 m 481.2283 83 l S
-n 0 0 m 481.2283 0 l S
-n 0 0 m 0 83 l S
-n 481.2283 0 m 481.2283 83 l S
-Q
-Q
-Q
-q
-1 0 0 1 57.02362 207.2236 cm
-Q
-q
-1 0 0 1 57.02362 207.2236 cm
-Q
-q
-1 0 0 1 51.02362 767.1969 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 0 0 cm
-q
-0 0 0 rg
-BT /F1 10 Tf 12 TL ET
-q
-1 0 0 1 6 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page 50) Tj T* ET
-Q
-Q
-q
-1 0 0 1 104.6457 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 97.4985 0 Td (21.4   Running tests) Tj T* -97.4985 0 Td ET
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
-q
-Q
-Q
-Q
- 
-endstream
-endobj
-382 0 obj
-<<
-/Length 4302
->>
-stream
-1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
-q
-1 0 0 1 57.02362 726.0236 cm
-q
-BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (22   Licenses) Tj T* ET
+BT 1 0 0 1 0 3.5 Tm 21 TL /F3 17.5 Tf .133333 .133333 .133333 rg (21   Licenses) Tj T* ET
 Q
 Q
 q
@@ -20092,16 +18402,17 @@ q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 104.6457 3 cm
-q
-BT 1 0 0 1 0 2 Tm 112.5085 0 Td 12 TL /F1 10 Tf 0 0 0 rg (22   Licenses) Tj T* -112.5085 0 Td ET
-Q
-Q
-q
-1 0 0 1 400.5827 3 cm
+1 0 0 1 6 3 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 49.39567 0 Td (Page 51) Tj T* -49.39567 0 Td ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page 48) Tj T* ET
+Q
+Q
+q
+1 0 0 1 104.6457 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 112.5085 0 Td (21   Licenses) Tj T* -112.5085 0 Td ET
 Q
 Q
 q
@@ -20119,9 +18430,9 @@ Q
  
 endstream
 endobj
-383 0 obj
+367 0 obj
 <<
-/Length 1028
+/Length 1064
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -20166,17 +18477,16 @@ q
 0 0 0 rg
 BT /F1 10 Tf 12 TL ET
 q
-1 0 0 1 6 3 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Page 52) Tj T* ET
-Q
-Q
-q
 1 0 0 1 104.6457 3 cm
 q
+BT 1 0 0 1 0 2 Tm 112.5085 0 Td 12 TL /F1 10 Tf 0 0 0 rg (21   Licenses) Tj T* -112.5085 0 Td ET
+Q
+Q
+q
+1 0 0 1 400.5827 3 cm
+q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 112.5085 0 Td (22   Licenses) Tj T* -112.5085 0 Td ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 49.39567 0 Td (Page 49) Tj T* -49.39567 0 Td ET
 Q
 Q
 q
@@ -20194,283 +18504,267 @@ Q
  
 endstream
 endobj
-384 0 obj
+368 0 obj
 <<
-/Nums [ 0 385 0 R 1 386 0 R 2 387 0 R 3 388 0 R 4 389 0 R 
-  5 390 0 R 6 391 0 R 7 392 0 R 8 393 0 R 9 394 0 R 
-  10 395 0 R 11 396 0 R 12 397 0 R 13 398 0 R 14 399 0 R 
-  15 400 0 R 16 401 0 R 17 402 0 R 18 403 0 R 19 404 0 R 
-  20 405 0 R 21 406 0 R 22 407 0 R 23 408 0 R 24 409 0 R 
-  25 410 0 R 26 411 0 R 27 412 0 R 28 413 0 R 29 414 0 R 
-  30 415 0 R 31 416 0 R 32 417 0 R 33 418 0 R 34 419 0 R 
-  35 420 0 R 36 421 0 R 37 422 0 R 38 423 0 R 39 424 0 R 
-  40 425 0 R 41 426 0 R 42 427 0 R 43 428 0 R 44 429 0 R 
-  45 430 0 R 46 431 0 R 47 432 0 R 48 433 0 R 49 434 0 R 
-  50 435 0 R 51 436 0 R ]
+/Nums [ 0 369 0 R 1 370 0 R 2 371 0 R 3 372 0 R 4 373 0 R 
+  5 374 0 R 6 375 0 R 7 376 0 R 8 377 0 R 9 378 0 R 
+  10 379 0 R 11 380 0 R 12 381 0 R 13 382 0 R 14 383 0 R 
+  15 384 0 R 16 385 0 R 17 386 0 R 18 387 0 R 19 388 0 R 
+  20 389 0 R 21 390 0 R 22 391 0 R 23 392 0 R 24 393 0 R 
+  25 394 0 R 26 395 0 R 27 396 0 R 28 397 0 R 29 398 0 R 
+  30 399 0 R 31 400 0 R 32 401 0 R 33 402 0 R 34 403 0 R 
+  35 404 0 R 36 405 0 R 37 406 0 R 38 407 0 R 39 408 0 R 
+  40 409 0 R 41 410 0 R 42 411 0 R 43 412 0 R 44 413 0 R 
+  45 414 0 R 46 415 0 R 47 416 0 R 48 417 0 R ]
 >>
 endobj
-385 0 obj
+369 0 obj
 <<
 /S /D /St 1
 >>
 endobj
-386 0 obj
+370 0 obj
 <<
 /S /D /St 2
 >>
 endobj
-387 0 obj
+371 0 obj
 <<
 /S /D /St 3
 >>
 endobj
-388 0 obj
+372 0 obj
 <<
 /S /D /St 4
 >>
 endobj
-389 0 obj
+373 0 obj
 <<
 /S /D /St 5
 >>
 endobj
-390 0 obj
+374 0 obj
 <<
 /S /D /St 6
 >>
 endobj
-391 0 obj
+375 0 obj
 <<
 /S /D /St 7
 >>
 endobj
-392 0 obj
+376 0 obj
 <<
 /S /D /St 8
 >>
 endobj
-393 0 obj
+377 0 obj
 <<
 /S /D /St 9
 >>
 endobj
-394 0 obj
+378 0 obj
 <<
 /S /D /St 10
 >>
 endobj
-395 0 obj
+379 0 obj
 <<
 /S /D /St 11
 >>
 endobj
-396 0 obj
+380 0 obj
 <<
 /S /D /St 12
 >>
 endobj
-397 0 obj
+381 0 obj
 <<
 /S /D /St 13
 >>
 endobj
-398 0 obj
+382 0 obj
 <<
 /S /D /St 14
 >>
 endobj
-399 0 obj
+383 0 obj
 <<
 /S /D /St 15
 >>
 endobj
-400 0 obj
+384 0 obj
 <<
 /S /D /St 16
 >>
 endobj
-401 0 obj
+385 0 obj
 <<
 /S /D /St 17
 >>
 endobj
-402 0 obj
+386 0 obj
 <<
 /S /D /St 18
 >>
 endobj
-403 0 obj
+387 0 obj
 <<
 /S /D /St 19
 >>
 endobj
-404 0 obj
+388 0 obj
 <<
 /S /D /St 20
 >>
 endobj
-405 0 obj
+389 0 obj
 <<
 /S /D /St 21
 >>
 endobj
-406 0 obj
+390 0 obj
 <<
 /S /D /St 22
 >>
 endobj
-407 0 obj
+391 0 obj
 <<
 /S /D /St 23
 >>
 endobj
-408 0 obj
+392 0 obj
 <<
 /S /D /St 24
 >>
 endobj
-409 0 obj
+393 0 obj
 <<
 /S /D /St 25
 >>
 endobj
-410 0 obj
+394 0 obj
 <<
 /S /D /St 26
 >>
 endobj
-411 0 obj
+395 0 obj
 <<
 /S /D /St 27
 >>
 endobj
-412 0 obj
+396 0 obj
 <<
 /S /D /St 28
 >>
 endobj
-413 0 obj
+397 0 obj
 <<
 /S /D /St 29
 >>
 endobj
-414 0 obj
+398 0 obj
 <<
 /S /D /St 30
 >>
 endobj
-415 0 obj
+399 0 obj
 <<
 /S /D /St 31
 >>
 endobj
-416 0 obj
+400 0 obj
 <<
 /S /D /St 32
 >>
 endobj
-417 0 obj
+401 0 obj
 <<
 /S /D /St 33
 >>
 endobj
-418 0 obj
+402 0 obj
 <<
 /S /D /St 34
 >>
 endobj
-419 0 obj
+403 0 obj
 <<
 /S /D /St 35
 >>
 endobj
-420 0 obj
+404 0 obj
 <<
 /S /D /St 36
 >>
 endobj
-421 0 obj
+405 0 obj
 <<
 /S /D /St 37
 >>
 endobj
-422 0 obj
+406 0 obj
 <<
 /S /D /St 38
 >>
 endobj
-423 0 obj
+407 0 obj
 <<
 /S /D /St 39
 >>
 endobj
-424 0 obj
+408 0 obj
 <<
 /S /D /St 40
 >>
 endobj
-425 0 obj
+409 0 obj
 <<
 /S /D /St 41
 >>
 endobj
-426 0 obj
+410 0 obj
 <<
 /S /D /St 42
 >>
 endobj
-427 0 obj
+411 0 obj
 <<
 /S /D /St 43
 >>
 endobj
-428 0 obj
+412 0 obj
 <<
 /S /D /St 44
 >>
 endobj
-429 0 obj
+413 0 obj
 <<
 /S /D /St 45
 >>
 endobj
-430 0 obj
+414 0 obj
 <<
 /S /D /St 46
 >>
 endobj
-431 0 obj
+415 0 obj
 <<
 /S /D /St 47
 >>
 endobj
-432 0 obj
+416 0 obj
 <<
 /S /D /St 48
 >>
 endobj
-433 0 obj
+417 0 obj
 <<
 /S /D /St 49
 >>
 endobj
-434 0 obj
-<<
-/S /D /St 50
->>
-endobj
-435 0 obj
-<<
-/S /D /St 51
->>
-endobj
-436 0 obj
-<<
-/S /D /St 52
->>
-endobj
 xref
-0 437
+0 418
 0000000000 65535 f 
 0000000073 00000 n 
 0000000218 00000 n 
@@ -20490,447 +18784,428 @@ xref
 0000059896 00000 n 
 0000060064 00000 n 
 0000060234 00000 n 
-0000060400 00000 n 
-0000060570 00000 n 
-0000060736 00000 n 
-0000060906 00000 n 
-0000061072 00000 n 
-0000061242 00000 n 
-0000061408 00000 n 
-0000061578 00000 n 
-0000061744 00000 n 
-0000061914 00000 n 
-0000062080 00000 n 
-0000062250 00000 n 
-0000062416 00000 n 
-0000062586 00000 n 
-0000062752 00000 n 
-0000062922 00000 n 
-0000063088 00000 n 
-0000063258 00000 n 
-0000063424 00000 n 
-0000063594 00000 n 
-0000063760 00000 n 
-0000063930 00000 n 
-0000064096 00000 n 
-0000064266 00000 n 
-0000064432 00000 n 
-0000064602 00000 n 
-0000064768 00000 n 
-0000064938 00000 n 
-0000065104 00000 n 
-0000065274 00000 n 
-0000065440 00000 n 
-0000065610 00000 n 
-0000065776 00000 n 
-0000065946 00000 n 
-0000066112 00000 n 
-0000066282 00000 n 
-0000066448 00000 n 
-0000066618 00000 n 
-0000066784 00000 n 
-0000066954 00000 n 
-0000067120 00000 n 
-0000067290 00000 n 
-0000067456 00000 n 
-0000067626 00000 n 
-0000067792 00000 n 
-0000067962 00000 n 
-0000068128 00000 n 
-0000068298 00000 n 
-0000068464 00000 n 
-0000068634 00000 n 
-0000068800 00000 n 
-0000068970 00000 n 
-0000069136 00000 n 
-0000069306 00000 n 
-0000069472 00000 n 
-0000069642 00000 n 
-0000069808 00000 n 
-0000069978 00000 n 
-0000070144 00000 n 
-0000070314 00000 n 
-0000070480 00000 n 
-0000070650 00000 n 
-0000070816 00000 n 
-0000070986 00000 n 
-0000071152 00000 n 
-0000071322 00000 n 
-0000071488 00000 n 
-0000071658 00000 n 
-0000071824 00000 n 
-0000072622 00000 n 
-0000072792 00000 n 
-0000072958 00000 n 
-0000073128 00000 n 
-0000073294 00000 n 
-0000073464 00000 n 
-0000073630 00000 n 
-0000073800 00000 n 
-0000073966 00000 n 
-0000074136 00000 n 
-0000074302 00000 n 
-0000074472 00000 n 
-0000074638 00000 n 
-0000074809 00000 n 
-0000074976 00000 n 
-0000075147 00000 n 
-0000075314 00000 n 
-0000075485 00000 n 
-0000075652 00000 n 
-0000075823 00000 n 
-0000075990 00000 n 
-0000076161 00000 n 
-0000076328 00000 n 
-0000076499 00000 n 
-0000076666 00000 n 
-0000076837 00000 n 
-0000077004 00000 n 
-0000077175 00000 n 
-0000077342 00000 n 
-0000077513 00000 n 
-0000077680 00000 n 
-0000077851 00000 n 
-0000078018 00000 n 
-0000078189 00000 n 
-0000078356 00000 n 
-0000078527 00000 n 
-0000078694 00000 n 
-0000078865 00000 n 
-0000079032 00000 n 
-0000079139 00000 n 
-0000079310 00000 n 
-0000079477 00000 n 
-0000079648 00000 n 
-0000079815 00000 n 
-0000079986 00000 n 
-0000080153 00000 n 
-0000080324 00000 n 
-0000080491 00000 n 
-0000080662 00000 n 
-0000080829 00000 n 
-0000080999 00000 n 
-0000081165 00000 n 
-0000081335 00000 n 
-0000081501 00000 n 
-0000081671 00000 n 
-0000081837 00000 n 
-0000082008 00000 n 
-0000082175 00000 n 
-0000082346 00000 n 
-0000082513 00000 n 
-0000082684 00000 n 
-0000082851 00000 n 
-0000083022 00000 n 
-0000083189 00000 n 
-0000083912 00000 n 
-0000084127 00000 n 
-0000084340 00000 n 
-0000084560 00000 n 
-0000084774 00000 n 
-0000085027 00000 n 
-0000085236 00000 n 
-0000085445 00000 n 
-0000085616 00000 n 
-0000085731 00000 n 
-0000085843 00000 n 
-0000086072 00000 n 
-0000086281 00000 n 
-0000086490 00000 n 
-0000086793 00000 n 
-0000087078 00000 n 
-0000087264 00000 n 
-0000087558 00000 n 
-0000087767 00000 n 
-0000087938 00000 n 
-0000088109 00000 n 
-0000088280 00000 n 
-0000088525 00000 n 
-0000088696 00000 n 
-0000088866 00000 n 
-0000088983 00000 n 
-0000089154 00000 n 
-0000089325 00000 n 
-0000089578 00000 n 
-0000089787 00000 n 
-0000089958 00000 n 
-0000090187 00000 n 
-0000090396 00000 n 
-0000090605 00000 n 
-0000090776 00000 n 
-0000090947 00000 n 
-0000091184 00000 n 
-0000091355 00000 n 
-0000091584 00000 n 
-0000091755 00000 n 
-0000091984 00000 n 
-0000092193 00000 n 
-0000092402 00000 n 
-0000092573 00000 n 
-0000092802 00000 n 
-0000093011 00000 n 
-0000093220 00000 n 
-0000093394 00000 n 
-0000093580 00000 n 
-0000093817 00000 n 
-0000094001 00000 n 
-0000094230 00000 n 
-0000094439 00000 n 
-0000094648 00000 n 
-0000094840 00000 n 
-0000095011 00000 n 
-0000095248 00000 n 
-0000095457 00000 n 
-0000095636 00000 n 
-0000095865 00000 n 
-0000096074 00000 n 
-0000096283 00000 n 
-0000096492 00000 n 
-0000096701 00000 n 
-0000096872 00000 n 
-0000097101 00000 n 
-0000097310 00000 n 
-0000097519 00000 n 
-0000097696 00000 n 
-0000103685 00000 n 
-0000110061 00000 n 
-0000110293 00000 n 
-0000110595 00000 n 
-0000110804 00000 n 
-0000111002 00000 n 
-0000111231 00000 n 
-0000111408 00000 n 
-0000111637 00000 n 
-0000111846 00000 n 
-0000112055 00000 n 
-0000112264 00000 n 
-0000112473 00000 n 
-0000112668 00000 n 
-0000112897 00000 n 
-0000113085 00000 n 
-0000113260 00000 n 
-0000113497 00000 n 
-0000113692 00000 n 
-0000113864 00000 n 
-0000114044 00000 n 
-0000114289 00000 n 
-0000114498 00000 n 
-0000114669 00000 n 
-0000114898 00000 n 
-0000116812 00000 n 
-0000128053 00000 n 
-0000128304 00000 n 
-0000129665 00000 n 
-0000131612 00000 n 
-0000167261 00000 n 
-0000167522 00000 n 
-0000168873 00000 n 
-0000170856 00000 n 
-0000182457 00000 n 
-0000182691 00000 n 
-0000183438 00000 n 
-0000183548 00000 n 
-0000183825 00000 n 
-0000183903 00000 n 
-0000184147 00000 n 
-0000184361 00000 n 
-0000184618 00000 n 
-0000184865 00000 n 
-0000185072 00000 n 
-0000185300 00000 n 
-0000185483 00000 n 
-0000185755 00000 n 
-0000185958 00000 n 
-0000186276 00000 n 
-0000186504 00000 n 
-0000186766 00000 n 
-0000186964 00000 n 
-0000187272 00000 n 
-0000187510 00000 n 
-0000187777 00000 n 
-0000188034 00000 n 
-0000188336 00000 n 
-0000188725 00000 n 
-0000189008 00000 n 
-0000189306 00000 n 
-0000189605 00000 n 
-0000189838 00000 n 
-0000190116 00000 n 
-0000190344 00000 n 
-0000190532 00000 n 
-0000190795 00000 n 
-0000191008 00000 n 
-0000191241 00000 n 
-0000191458 00000 n 
-0000191715 00000 n 
-0000191928 00000 n 
-0000192221 00000 n 
-0000192468 00000 n 
-0000192746 00000 n 
-0000192944 00000 n 
-0000193172 00000 n 
-0000193420 00000 n 
-0000193689 00000 n 
-0000193958 00000 n 
-0000194266 00000 n 
-0000194559 00000 n 
-0000194859 00000 n 
-0000195127 00000 n 
-0000195320 00000 n 
-0000195557 00000 n 
-0000195784 00000 n 
-0000196016 00000 n 
-0000196268 00000 n 
-0000196520 00000 n 
-0000196718 00000 n 
-0000196960 00000 n 
-0000197257 00000 n 
-0000197524 00000 n 
-0000197741 00000 n 
-0000197958 00000 n 
-0000198180 00000 n 
-0000198372 00000 n 
-0000198625 00000 n 
-0000198940 00000 n 
-0000199255 00000 n 
-0000199508 00000 n 
-0000199702 00000 n 
-0000199985 00000 n 
-0000200192 00000 n 
-0000200413 00000 n 
-0000200694 00000 n 
-0000200958 00000 n 
-0000201231 00000 n 
-0000201469 00000 n 
-0000201657 00000 n 
-0000202141 00000 n 
-0000202860 00000 n 
-0000212782 00000 n 
-0000220761 00000 n 
-0000224822 00000 n 
-0000237169 00000 n 
-0000243552 00000 n 
-0000253368 00000 n 
-0000261905 00000 n 
-0000264605 00000 n 
-0000270023 00000 n 
-0000276419 00000 n 
-0000281648 00000 n 
-0000286215 00000 n 
-0000295167 00000 n 
-0000302308 00000 n 
-0000310037 00000 n 
-0000319273 00000 n 
-0000327371 00000 n 
-0000336659 00000 n 
-0000345426 00000 n 
-0000350678 00000 n 
-0000362660 00000 n 
-0000369904 00000 n 
-0000376395 00000 n 
-0000381628 00000 n 
-0000392056 00000 n 
-0000402786 00000 n 
-0000410488 00000 n 
-0000419763 00000 n 
-0000427569 00000 n 
-0000433624 00000 n 
-0000438982 00000 n 
-0000443882 00000 n 
-0000450207 00000 n 
-0000456592 00000 n 
-0000457906 00000 n 
-0000462889 00000 n 
-0000465877 00000 n 
-0000470554 00000 n 
-0000475393 00000 n 
-0000479393 00000 n 
-0000484017 00000 n 
-0000488755 00000 n 
-0000491291 00000 n 
-0000497123 00000 n 
-0000504477 00000 n 
-0000509337 00000 n 
-0000515098 00000 n 
-0000520951 00000 n 
-0000526112 00000 n 
-0000530467 00000 n 
-0000531548 00000 n 
-0000532173 00000 n 
-0000532208 00000 n 
-0000532243 00000 n 
-0000532278 00000 n 
-0000532313 00000 n 
-0000532348 00000 n 
-0000532383 00000 n 
-0000532418 00000 n 
-0000532453 00000 n 
-0000532488 00000 n 
-0000532524 00000 n 
-0000532560 00000 n 
-0000532596 00000 n 
-0000532632 00000 n 
-0000532668 00000 n 
-0000532704 00000 n 
-0000532740 00000 n 
-0000532776 00000 n 
-0000532812 00000 n 
-0000532848 00000 n 
-0000532884 00000 n 
-0000532920 00000 n 
-0000532956 00000 n 
-0000532992 00000 n 
-0000533028 00000 n 
-0000533064 00000 n 
-0000533100 00000 n 
-0000533136 00000 n 
-0000533172 00000 n 
-0000533208 00000 n 
-0000533244 00000 n 
-0000533280 00000 n 
-0000533316 00000 n 
-0000533352 00000 n 
-0000533388 00000 n 
-0000533424 00000 n 
-0000533460 00000 n 
-0000533496 00000 n 
-0000533532 00000 n 
-0000533568 00000 n 
-0000533604 00000 n 
-0000533640 00000 n 
-0000533676 00000 n 
-0000533712 00000 n 
-0000533748 00000 n 
-0000533784 00000 n 
-0000533820 00000 n 
-0000533856 00000 n 
-0000533892 00000 n 
-0000533928 00000 n 
-0000533964 00000 n 
-0000534000 00000 n 
+0000060402 00000 n 
+0000060572 00000 n 
+0000060740 00000 n 
+0000060910 00000 n 
+0000061078 00000 n 
+0000061248 00000 n 
+0000061416 00000 n 
+0000061586 00000 n 
+0000061754 00000 n 
+0000061924 00000 n 
+0000062092 00000 n 
+0000062262 00000 n 
+0000062430 00000 n 
+0000062600 00000 n 
+0000062768 00000 n 
+0000062938 00000 n 
+0000063104 00000 n 
+0000063274 00000 n 
+0000063440 00000 n 
+0000063610 00000 n 
+0000063776 00000 n 
+0000063946 00000 n 
+0000064112 00000 n 
+0000064282 00000 n 
+0000064448 00000 n 
+0000064618 00000 n 
+0000064784 00000 n 
+0000064954 00000 n 
+0000065120 00000 n 
+0000065290 00000 n 
+0000065456 00000 n 
+0000065626 00000 n 
+0000065792 00000 n 
+0000065962 00000 n 
+0000066128 00000 n 
+0000066298 00000 n 
+0000066464 00000 n 
+0000066634 00000 n 
+0000066800 00000 n 
+0000066970 00000 n 
+0000067136 00000 n 
+0000067306 00000 n 
+0000067472 00000 n 
+0000067642 00000 n 
+0000067808 00000 n 
+0000067978 00000 n 
+0000068144 00000 n 
+0000068314 00000 n 
+0000068480 00000 n 
+0000068650 00000 n 
+0000068816 00000 n 
+0000068986 00000 n 
+0000069152 00000 n 
+0000069322 00000 n 
+0000069488 00000 n 
+0000069658 00000 n 
+0000069824 00000 n 
+0000069994 00000 n 
+0000070160 00000 n 
+0000070330 00000 n 
+0000070496 00000 n 
+0000070666 00000 n 
+0000070832 00000 n 
+0000071002 00000 n 
+0000071168 00000 n 
+0000071338 00000 n 
+0000071504 00000 n 
+0000071674 00000 n 
+0000071840 00000 n 
+0000072638 00000 n 
+0000072808 00000 n 
+0000072974 00000 n 
+0000073144 00000 n 
+0000073310 00000 n 
+0000073480 00000 n 
+0000073646 00000 n 
+0000073816 00000 n 
+0000073982 00000 n 
+0000074152 00000 n 
+0000074318 00000 n 
+0000074488 00000 n 
+0000074654 00000 n 
+0000074825 00000 n 
+0000074992 00000 n 
+0000075163 00000 n 
+0000075330 00000 n 
+0000075501 00000 n 
+0000075668 00000 n 
+0000075839 00000 n 
+0000076006 00000 n 
+0000076177 00000 n 
+0000076344 00000 n 
+0000076515 00000 n 
+0000076682 00000 n 
+0000076853 00000 n 
+0000077020 00000 n 
+0000077191 00000 n 
+0000077358 00000 n 
+0000077529 00000 n 
+0000077696 00000 n 
+0000077867 00000 n 
+0000078034 00000 n 
+0000078205 00000 n 
+0000078372 00000 n 
+0000078543 00000 n 
+0000078710 00000 n 
+0000078881 00000 n 
+0000079048 00000 n 
+0000079219 00000 n 
+0000079386 00000 n 
+0000079557 00000 n 
+0000079724 00000 n 
+0000079895 00000 n 
+0000080062 00000 n 
+0000080233 00000 n 
+0000080400 00000 n 
+0000080571 00000 n 
+0000080738 00000 n 
+0000080909 00000 n 
+0000081076 00000 n 
+0000081247 00000 n 
+0000081414 00000 n 
+0000081585 00000 n 
+0000081752 00000 n 
+0000081923 00000 n 
+0000082090 00000 n 
+0000082261 00000 n 
+0000082428 00000 n 
+0000083116 00000 n 
+0000083223 00000 n 
+0000083438 00000 n 
+0000083651 00000 n 
+0000083871 00000 n 
+0000084085 00000 n 
+0000084338 00000 n 
+0000084455 00000 n 
+0000084664 00000 n 
+0000084873 00000 n 
+0000085044 00000 n 
+0000085273 00000 n 
+0000085388 00000 n 
+0000085500 00000 n 
+0000085709 00000 n 
+0000085918 00000 n 
+0000086221 00000 n 
+0000086506 00000 n 
+0000086692 00000 n 
+0000086986 00000 n 
+0000087195 00000 n 
+0000087366 00000 n 
+0000087537 00000 n 
+0000087708 00000 n 
+0000087953 00000 n 
+0000088124 00000 n 
+0000088294 00000 n 
+0000088465 00000 n 
+0000088636 00000 n 
+0000088889 00000 n 
+0000089098 00000 n 
+0000089269 00000 n 
+0000089498 00000 n 
+0000089707 00000 n 
+0000089916 00000 n 
+0000090087 00000 n 
+0000090258 00000 n 
+0000090495 00000 n 
+0000090666 00000 n 
+0000090895 00000 n 
+0000091066 00000 n 
+0000091295 00000 n 
+0000091504 00000 n 
+0000091713 00000 n 
+0000091884 00000 n 
+0000092113 00000 n 
+0000092322 00000 n 
+0000092531 00000 n 
+0000092705 00000 n 
+0000092891 00000 n 
+0000093128 00000 n 
+0000093312 00000 n 
+0000093541 00000 n 
+0000093750 00000 n 
+0000093959 00000 n 
+0000094151 00000 n 
+0000094322 00000 n 
+0000094559 00000 n 
+0000094768 00000 n 
+0000094947 00000 n 
+0000095176 00000 n 
+0000095385 00000 n 
+0000095594 00000 n 
+0000095803 00000 n 
+0000096012 00000 n 
+0000096183 00000 n 
+0000096412 00000 n 
+0000096621 00000 n 
+0000096830 00000 n 
+0000097007 00000 n 
+0000102996 00000 n 
+0000109372 00000 n 
+0000109604 00000 n 
+0000109906 00000 n 
+0000110115 00000 n 
+0000110313 00000 n 
+0000110542 00000 n 
+0000110719 00000 n 
+0000110948 00000 n 
+0000111157 00000 n 
+0000111366 00000 n 
+0000111583 00000 n 
+0000111812 00000 n 
+0000112000 00000 n 
+0000112229 00000 n 
+0000112438 00000 n 
+0000112609 00000 n 
+0000112838 00000 n 
+0000114752 00000 n 
+0000125993 00000 n 
+0000126244 00000 n 
+0000127605 00000 n 
+0000129540 00000 n 
+0000165189 00000 n 
+0000165450 00000 n 
+0000166792 00000 n 
+0000168763 00000 n 
+0000180364 00000 n 
+0000180598 00000 n 
+0000181341 00000 n 
+0000181451 00000 n 
+0000181728 00000 n 
+0000181806 00000 n 
+0000182050 00000 n 
+0000182264 00000 n 
+0000182562 00000 n 
+0000182790 00000 n 
+0000183067 00000 n 
+0000183309 00000 n 
+0000183531 00000 n 
+0000183788 00000 n 
+0000184046 00000 n 
+0000184334 00000 n 
+0000184592 00000 n 
+0000184875 00000 n 
+0000185082 00000 n 
+0000185310 00000 n 
+0000185493 00000 n 
+0000185765 00000 n 
+0000185968 00000 n 
+0000186286 00000 n 
+0000186514 00000 n 
+0000186776 00000 n 
+0000186974 00000 n 
+0000187282 00000 n 
+0000187520 00000 n 
+0000187787 00000 n 
+0000188044 00000 n 
+0000188346 00000 n 
+0000188735 00000 n 
+0000189018 00000 n 
+0000189316 00000 n 
+0000189615 00000 n 
+0000189848 00000 n 
+0000190126 00000 n 
+0000190354 00000 n 
+0000190542 00000 n 
+0000190805 00000 n 
+0000191018 00000 n 
+0000191251 00000 n 
+0000191468 00000 n 
+0000191725 00000 n 
+0000191938 00000 n 
+0000192231 00000 n 
+0000192478 00000 n 
+0000192756 00000 n 
+0000192954 00000 n 
+0000193182 00000 n 
+0000193430 00000 n 
+0000193699 00000 n 
+0000193968 00000 n 
+0000194276 00000 n 
+0000194569 00000 n 
+0000194869 00000 n 
+0000195137 00000 n 
+0000195330 00000 n 
+0000195567 00000 n 
+0000195794 00000 n 
+0000196026 00000 n 
+0000196278 00000 n 
+0000196530 00000 n 
+0000196728 00000 n 
+0000196970 00000 n 
+0000197267 00000 n 
+0000197534 00000 n 
+0000197751 00000 n 
+0000197968 00000 n 
+0000198190 00000 n 
+0000198382 00000 n 
+0000198594 00000 n 
+0000198806 00000 n 
+0000198994 00000 n 
+0000199451 00000 n 
+0000200170 00000 n 
+0000210117 00000 n 
+0000217463 00000 n 
+0000221524 00000 n 
+0000231431 00000 n 
+0000240261 00000 n 
+0000248437 00000 n 
+0000255531 00000 n 
+0000258231 00000 n 
+0000263649 00000 n 
+0000270045 00000 n 
+0000275274 00000 n 
+0000279841 00000 n 
+0000288793 00000 n 
+0000295934 00000 n 
+0000303663 00000 n 
+0000312899 00000 n 
+0000320997 00000 n 
+0000330285 00000 n 
+0000339052 00000 n 
+0000344304 00000 n 
+0000356286 00000 n 
+0000363530 00000 n 
+0000370021 00000 n 
+0000375254 00000 n 
+0000385682 00000 n 
+0000396412 00000 n 
+0000404114 00000 n 
+0000408336 00000 n 
+0000416142 00000 n 
+0000422197 00000 n 
+0000427555 00000 n 
+0000432455 00000 n 
+0000438780 00000 n 
+0000445165 00000 n 
+0000446479 00000 n 
+0000451462 00000 n 
+0000454450 00000 n 
+0000459127 00000 n 
+0000463966 00000 n 
+0000467966 00000 n 
+0000472590 00000 n 
+0000477328 00000 n 
+0000479864 00000 n 
+0000485696 00000 n 
+0000488833 00000 n 
+0000489720 00000 n 
+0000494039 00000 n 
+0000495156 00000 n 
+0000495745 00000 n 
+0000495780 00000 n 
+0000495815 00000 n 
+0000495850 00000 n 
+0000495885 00000 n 
+0000495920 00000 n 
+0000495955 00000 n 
+0000495990 00000 n 
+0000496025 00000 n 
+0000496060 00000 n 
+0000496096 00000 n 
+0000496132 00000 n 
+0000496168 00000 n 
+0000496204 00000 n 
+0000496240 00000 n 
+0000496276 00000 n 
+0000496312 00000 n 
+0000496348 00000 n 
+0000496384 00000 n 
+0000496420 00000 n 
+0000496456 00000 n 
+0000496492 00000 n 
+0000496528 00000 n 
+0000496564 00000 n 
+0000496600 00000 n 
+0000496636 00000 n 
+0000496672 00000 n 
+0000496708 00000 n 
+0000496744 00000 n 
+0000496780 00000 n 
+0000496816 00000 n 
+0000496852 00000 n 
+0000496888 00000 n 
+0000496924 00000 n 
+0000496960 00000 n 
+0000496996 00000 n 
+0000497032 00000 n 
+0000497068 00000 n 
+0000497104 00000 n 
+0000497140 00000 n 
+0000497176 00000 n 
+0000497212 00000 n 
+0000497248 00000 n 
+0000497284 00000 n 
+0000497320 00000 n 
+0000497356 00000 n 
+0000497392 00000 n 
+0000497428 00000 n 
+0000497464 00000 n 
 trailer
 <<
 /ID 
-[<66725fdffc10cbd7e5d75cf91a7309af><66725fdffc10cbd7e5d75cf91a7309af>]
+[<bc9da38c1e583e4da310b2d13c3a6cf1><bc9da38c1e583e4da310b2d13c3a6cf1>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 258 0 R
-/Root 257 0 R
-/Size 437
+/Info 247 0 R
+/Root 246 0 R
+/Size 418
 >>
 startxref
-534036
+497500
 %%EOF
 %BeginExifToolUpdate
-258 0 obj
+247 0 obj
 <<
 /Author (rst2pdf project; Roberto Alsina)
-/CreationDate (D:20240605203543+00'00')
+/CreationDate (D:20241224161726+00'00')
 /Creator (\(unspecified\))
 /Keywords ()
-/ModDate (D:20240605203543+00'00')
+/ModDate (D:20241224161726+00'00')
 /Producer (ReportLab PDF Library - www.reportlab.com)
-/Subject (v0.102 r2024060500)
+/Subject (v0.103 r2024122400)
 /Title (How to use rst2pdf)
 /Trapped /False
 >>
@@ -20938,17 +19213,17 @@ endobj
 xref
 0 1
 0000000000 65535 f 
-258 1
-0000543032 00000 n 
+247 1
+0000506116 00000 n 
 trailer
 <<
-/ID [ <66725fdffc10cbd7e5d75cf91a7309af> <68725fdffc10cbd7e5d75cf91a7309af> ]
-/Info 258 0 R
-/Root 257 0 R
-/Size 437
-/Prev 534036
+/ID [ <bc9da38c1e583e4da310b2d13c3a6cf1> <be9da38c1e583e4da310b2d13c3a6cf1> ]
+/Info 247 0 R
+/Root 246 0 R
+/Size 418
+/Prev 497500
 >>
-%EndExifToolUpdate 543011
+%EndExifToolUpdate 506095
 startxref
-543340
+506424
 %%EOF


### PR DESCRIPTION
* Update docs with the 0.103 versions.
* Update README for Python 3.9 minimum version and using uv if installing from source.
